### PR TITLE
split the client into a separate library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,12 @@ AC_SUBST(PACKAGE_VERSION)
 #
 # libzpipes -version-info
 LTVER="0:0:0"
+
+# libzpipes_client -version-info
+CLIENT_LTVER="0:0:0"
+
 AC_SUBST(LTVER)
+AC_SUBST(CLIENT_LTVER)
 
 # Capture c flags
 ZPIPES_ORIG_CFLAGS="${CFLAGS:-none}"
@@ -270,5 +275,5 @@ AC_TYPE_SIGNAL
 AC_CHECK_FUNCS(perror gettimeofday memset getifaddrs freeifaddrs)
 
 # Specify output files
-AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile src/libzpipes.pc])
+AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile src/libzpipes.pc src/libzpipesclient.pc])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,18 +1,21 @@
-lib_LTLIBRARIES = libzpipes.la
+lib_LTLIBRARIES = libzpipes.la libzpipesclient.la
+
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = libzpipes.pc
+pkgconfig_DATA = libzpipes.pc libzpipesclient.pc
 
 include_HEADERS = ../include/zpipes.h ../include/zpipes_client.h
 
-libzpipes_la_SOURCES = zpipes_agent.c zpipes.c zpipes_client.c
+libzpipes_la_SOURCES = zpipes_agent.c zpipes.c
+libzpipesclient_la_SOURCES = zpipes_client.c
 
 AM_CFLAGS = -g
 AM_CPPFLAGS = -I$(top_srcdir)/include
 bin_PROGRAMS = zpipes_selftest
 
-zpipes_selftest_LDADD = libzpipes.la
+zpipes_selftest_LDADD = libzpipes.la libzpipesclient.la
 zpipes_selftest_SOURCES = zpipes_selftest.c
 
 libzpipes_la_LDFLAGS = -version-info @LTVER@
+libzpipesclient_la_LDFLAGS = -version-info @CLIENT_LTVER@
 
 TESTS = zpipes_selftest

--- a/src/libzpipesclient.pc.in
+++ b/src/libzpipesclient.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libzpipesclient
+Description: reliable & distributed named pipes client
+Version: @VERSION@
+Requires: libzmq libczmq libzyre
+Libs: -L${libdir} -lzpipesclient
+Cflags: -I${includedir}


### PR DESCRIPTION
still a dep on libzpipes due to tests using a self-hosted broker
