### PR TITLE
Fix inability to close pipe in "expecting chunk" state

### DIFF
--- a/src/zpipes_server.xml
+++ b/src/zpipes_server.xml
@@ -37,6 +37,11 @@
             <action name = "fetch chunk from pipe" />
             <action name = "send" message = "fetched" />
         </event>
+        <event name = "close">
+            <action name = "close pipe" />
+            <action name = "send" message = "closed" />
+            <action name = "terminate" />
+        </event>
         <event name = "pipe terminated" next = "reading">
             <action name = "clear pending reads" />
             <action name = "send" message = "end of pipe" />


### PR DESCRIPTION
When doing a blocked read and EINTR occurs, the server state
was stuck in expecting chunk, and would't accept a close
command.

Fixes #27
