### PR TITLE
Problem: after reader closes, WRITE asserts

### DIFF
--- a/src/zpipes_server.xml
+++ b/src/zpipes_server.xml
@@ -77,6 +77,10 @@
             <action name = "close pipe writer" />
             <action name = "terminate" />
         </event>
+        <!-- Pipe has been closed by reader, so discard data -->
+        <event name = "pipe shut" next = "writing">
+            <action name = "send" message = "WRITE FAILED" />
+        </event>
         <!-- We get this if a reader closed their end of the pipe -->
         <event name = "reader dropped">
             <action name = "close pipe writer" />


### PR DESCRIPTION
No semantics were defined for WRITE on a pipe with closed reader.
Solution: writing on pipe where reader closed its send causes an
error. Handled in state machine with new pipe_shut event in the
'processing write' state.

Added test case for #39.

Fixes #39.
