### PR TITLE
Problem: does not handle dropped writer properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_script:
 - git clone git://github.com/jedisct1/libsodium.git
 - git clone git://github.com/zeromq/libzmq.git
 - git clone git://github.com/zeromq/czmq.git
+- cd czmq && git checkout v2.2.0 && cd ..
 - git clone git://github.com/zeromq/zyre.git
 - for project in libsodium libzmq czmq zyre; do
 -     cd $project

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ before_script:
 - sudo apt-get install uuid-dev
 
 - git clone git://github.com/jedisct1/libsodium.git
-- git clone git://github.com/zeromq/libzmq.git
+- git clone git://github.com/zeromq/zeromq4-x.git
 - git clone git://github.com/zeromq/czmq.git
 - cd czmq && git checkout v2.2.0 && cd ..
 - git clone git://github.com/zeromq/zyre.git
-- for project in libsodium libzmq czmq zyre; do
+- for project in libsodium zeromq4-x czmq zyre; do
 -     cd $project
 -     ./autogen.sh
 -     ./configure && make check

--- a/include/zpipes_msg.h
+++ b/include/zpipes_msg.h
@@ -125,14 +125,14 @@ CZMQ_EXPORT void
 //  ZMQ_ROUTER, then parses the first frame as a routing_id. Destroys msg
 //  and nullifies the msg refernce.
 CZMQ_EXPORT zpipes_msg_t *
-    zpipes_msg_decode (zmsg_t **msg_p, int socket_type);
+    zpipes_msg_decode (zmsg_t **msg_p);
 
 //  Encode zpipes_msg into zmsg and destroy it. Returns a newly created
 //  object or NULL if error. Use when not in control of sending the message.
 //  If the socket_type is ZMQ_ROUTER, then stores the routing_id as the
 //  first frame of the resulting message.
 CZMQ_EXPORT zmsg_t *
-    zpipes_msg_encode (zpipes_msg_t *self, int socket_type);
+    zpipes_msg_encode (zpipes_msg_t **self_p);
 
 //  Receive and parse a zpipes_msg from the socket. Returns new object, 
 //  or NULL if error. Will block if there's no message waiting.
@@ -151,6 +151,114 @@ CZMQ_EXPORT int
 //  Send the zpipes_msg to the output, and do not destroy it
 CZMQ_EXPORT int
     zpipes_msg_send_again (zpipes_msg_t *self, void *output);
+
+//  Encode the INPUT 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_input (
+        const char *pipename);
+
+//  Encode the INPUT_OK 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_input_ok (
+);
+
+//  Encode the INPUT_FAILED 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_input_failed (
+        const char *reason);
+
+//  Encode the OUTPUT 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_output (
+        const char *pipename);
+
+//  Encode the OUTPUT_OK 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_output_ok (
+);
+
+//  Encode the OUTPUT_FAILED 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_output_failed (
+        const char *reason);
+
+//  Encode the READ 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_read (
+        uint32_t size,
+        uint32_t timeout);
+
+//  Encode the READ_OK 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_read_ok (
+        zchunk_t *chunk);
+
+//  Encode the READ_END 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_read_end (
+);
+
+//  Encode the READ_TIMEOUT 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_read_timeout (
+);
+
+//  Encode the READ_FAILED 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_read_failed (
+        const char *reason);
+
+//  Encode the WRITE 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_write (
+        zchunk_t *chunk,
+        uint32_t timeout);
+
+//  Encode the WRITE_OK 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_write_ok (
+);
+
+//  Encode the WRITE_TIMEOUT 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_write_timeout (
+);
+
+//  Encode the WRITE_FAILED 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_write_failed (
+        const char *reason);
+
+//  Encode the CLOSE 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_close (
+);
+
+//  Encode the CLOSE_OK 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_close_ok (
+);
+
+//  Encode the CLOSE_FAILED 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_close_failed (
+        const char *reason);
+
+//  Encode the PING 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_ping (
+);
+
+//  Encode the PING_OK 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_ping_ok (
+);
+
+//  Encode the INVALID 
+CZMQ_EXPORT zmsg_t *
+    zpipes_msg_encode_invalid (
+);
+
 
 //  Send the INPUT to the output in one step
 CZMQ_EXPORT int

--- a/src/zpipes_server.xml
+++ b/src/zpipes_server.xml
@@ -35,7 +35,7 @@
 
     <state name = "writing" inherit = "external">
         <event name = "WRITE" next = "processing write">
-            <action name = "look for pipe reader" />
+            <action name = "process write request" />
         </event>
         <!-- Does not affect writer state -->
         <event name = "READ">
@@ -102,7 +102,7 @@
 
     <state name = "reading" inherit = "external">
         <event name = "READ" next = "processing read">
-            <action name = "look for pipe data" />
+            <action name = "process read request" />
         </event>
         <!-- Does not affect reader state -->
         <event name = "WRITE">
@@ -127,12 +127,12 @@
     pipe.
 
     <state name = "processing read" inherit = "internal">
-        <!-- either immediately, or when data arrives -->
+        <!-- Either immediately, or when data arrives -->
         <event name = "have data" next = "reading">
             <action name = "collect data to send" />
             <action name = "send" message = "READ OK" />
         </event>
-        <!-- exception event if not enough data yet -->
+        <!-- Exception event if not enough data yet -->
         <event name = "not enough data" />
         <!-- Client asked for zero bytes -->
         <event name = "zero read" next = "reading">
@@ -157,8 +157,10 @@
             <action name = "terminate" />
         </event>
         <!-- We get this if a writer closed their end of the pipe -->
-        <event name = "writer dropped">
+        <event name = "writer dropped" next = "reading">
             <action name = "close pipe reader" />
+            <action name = "collect data to send" />
+            <action name = "send" message = "READ OK" />
         </event>
     </state>
 

--- a/src/zpipes_server_engine.h
+++ b/src/zpipes_server_engine.h
@@ -528,16 +528,22 @@ s_client_execute (s_client_t *self, int event)
         self->event = self->next_event;
         self->next_event = NULL_event;
         self->exception = NULL_event;
+        zclock_log ("%6d: %s:",
+            self->unique_id, s_state_name [self->state]);
+        zclock_log ("%6d:     %s",
+            self->unique_id, s_event_name [self->event]);
 
         switch (self->state) {
             case start_state:
                 if (self->event == output_event) {
                     if (!self->exception) {
                         //  lookup or create pipe
+                        zclock_log ("%6d:         $ lookup or create pipe", self->unique_id);
                         lookup_or_create_pipe (&self->client);
                     }
                     if (!self->exception) {
                         //  open pipe writer
+                        zclock_log ("%6d:         $ open pipe writer", self->unique_id);
                         open_pipe_writer (&self->client);
                     }
                     if (!self->exception)
@@ -547,10 +553,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == input_event) {
                     if (!self->exception) {
                         //  lookup or create pipe
+                        zclock_log ("%6d:         $ lookup or create pipe", self->unique_id);
                         lookup_or_create_pipe (&self->client);
                     }
                     if (!self->exception) {
                         //  open pipe reader
+                        zclock_log ("%6d:         $ open pipe reader", self->unique_id);
                         open_pipe_reader (&self->client);
                     }
                     if (!self->exception)
@@ -560,6 +568,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
+                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -579,6 +588,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -586,6 +596,7 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
+                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -593,6 +604,7 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -602,6 +614,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ok_event) {
                     if (!self->exception) {
                         //  send output_ok
+                        zclock_log ("%6d:         $ send OUTPUT_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_OUTPUT_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -614,6 +627,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == error_event) {
                     if (!self->exception) {
                         //  send output_failed
+                        zclock_log ("%6d:         $ send OUTPUT_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_OUTPUT_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -621,6 +635,7 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -639,6 +654,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == write_event) {
                     if (!self->exception) {
                         //  process write request
+                        zclock_log ("%6d:         $ process write request", self->unique_id);
                         process_write_request (&self->client);
                     }
                     if (!self->exception)
@@ -648,6 +664,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == read_event) {
                     if (!self->exception) {
                         //  send invalid
+                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -658,10 +675,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  close pipe writer
+                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
+                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -674,10 +693,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe writer
+                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -685,6 +706,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == reader_dropped_event) {
                     if (!self->exception) {
                         //  close pipe writer
+                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                 }
@@ -692,6 +714,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
+                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -711,6 +734,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -718,6 +742,7 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
+                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -725,6 +750,7 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -734,10 +760,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == have_reader_event) {
                     if (!self->exception) {
                         //  pass data to reader
+                        zclock_log ("%6d:         $ pass data to reader", self->unique_id);
                         pass_data_to_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  send write_ok
+                        zclock_log ("%6d:         $ send WRITE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -750,6 +778,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == wakeup_event) {
                     if (!self->exception) {
                         //  send write_timeout
+                        zclock_log ("%6d:         $ send WRITE_TIMEOUT", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_TIMEOUT);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -762,6 +791,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  send write_failed
+                        zclock_log ("%6d:         $ send WRITE_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -769,10 +799,12 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  close pipe writer
+                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
+                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -785,10 +817,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe writer
+                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -796,6 +830,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == pipe_shut_event) {
                     if (!self->exception) {
                         //  send write_failed
+                        zclock_log ("%6d:         $ send WRITE_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -808,6 +843,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == reader_dropped_event) {
                     if (!self->exception) {
                         //  close pipe writer
+                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                 }
@@ -815,6 +851,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
+                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -836,6 +873,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ok_event) {
                     if (!self->exception) {
                         //  send input_ok
+                        zclock_log ("%6d:         $ send INPUT_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INPUT_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -848,6 +886,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == error_event) {
                     if (!self->exception) {
                         //  send input_failed
+                        zclock_log ("%6d:         $ send INPUT_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INPUT_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -855,6 +894,7 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -873,6 +913,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == read_event) {
                     if (!self->exception) {
                         //  process read request
+                        zclock_log ("%6d:         $ process read request", self->unique_id);
                         process_read_request (&self->client);
                     }
                     if (!self->exception)
@@ -882,6 +923,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == write_event) {
                     if (!self->exception) {
                         //  send invalid
+                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -892,10 +934,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  close pipe reader
+                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
+                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -908,10 +952,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe reader
+                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -919,6 +965,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == writer_dropped_event) {
                     if (!self->exception) {
                         //  close pipe reader
+                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                 }
@@ -926,6 +973,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
+                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -945,6 +993,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -952,6 +1001,7 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
+                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -959,6 +1009,7 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -968,10 +1019,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == have_data_event) {
                     if (!self->exception) {
                         //  collect data to send
+                        zclock_log ("%6d:         $ collect data to send", self->unique_id);
                         collect_data_to_send (&self->client);
                     }
                     if (!self->exception) {
                         //  send read_ok
+                        zclock_log ("%6d:         $ send READ_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -987,6 +1040,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == zero_read_event) {
                     if (!self->exception) {
                         //  send read_end
+                        zclock_log ("%6d:         $ send READ_END", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_END);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -999,6 +1053,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == pipe_shut_event) {
                     if (!self->exception) {
                         //  send read_end
+                        zclock_log ("%6d:         $ send READ_END", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_END);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1011,6 +1066,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == wakeup_event) {
                     if (!self->exception) {
                         //  send read_timeout
+                        zclock_log ("%6d:         $ send READ_TIMEOUT", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_TIMEOUT);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1023,6 +1079,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  send read_failed
+                        zclock_log ("%6d:         $ send READ_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1030,10 +1087,12 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  close pipe reader
+                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
+                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1046,10 +1105,12 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe reader
+                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1057,14 +1118,17 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == writer_dropped_event) {
                     if (!self->exception) {
                         //  close pipe reader
+                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  collect data to send
+                        zclock_log ("%6d:         $ collect data to send", self->unique_id);
                         collect_data_to_send (&self->client);
                     }
                     if (!self->exception) {
                         //  send read_ok
+                        zclock_log ("%6d:         $ send READ_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1077,6 +1141,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
+                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1098,6 +1163,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
+                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1117,6 +1183,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1124,6 +1191,7 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
+                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1131,6 +1199,7 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
+                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1140,6 +1209,7 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
+                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1159,6 +1229,8 @@ s_client_execute (s_client_t *self, int event)
         }
         //  If we had an exception event, interrupt normal programming
         if (self->exception) {
+            zclock_log ("%6d:         ! %s",
+                self->unique_id, s_event_name [self->exception]);
             self->next_event = self->exception;
         }
         if (self->next_event == terminate_event) {
@@ -1167,6 +1239,8 @@ s_client_execute (s_client_t *self, int event)
             break;
         }
         else {
+            zclock_log ("%6d:         > %s",
+                self->unique_id, s_state_name [self->state]);
             if (self->next_event == NULL_event)
                 //  Get next valid message from mailbox, if any
                 self->next_event = s_client_filter_mailbox (self);


### PR DESCRIPTION
When waiting for read, blocks if the writer drops. Solution is to
return a short read, or read_end if there's zero data.

Fixes #41.
