### PR TITLE
Problem: segfault at zpipes_server_engine.h:521

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ src/zpipes_test_cluster
 doit*
 *.la
 *.pc
-
+zpipes_test_cluster.log
+zpipes_test_cluster.trs

--- a/src/zpipes_server.c
+++ b/src/zpipes_server.c
@@ -217,7 +217,9 @@ pipe_attach_local_reader (pipe_t *self, client_t *reader)
             zmsg_addstr (msg, self->name);
             zyre_whisper (self->server->zyre, self->remote, &msg);
         }
-        engine_send_event (self->writer, have_reader_event);
+        else
+            engine_send_event (self->writer, have_reader_event);
+
         return 0;
     }
     return -1;                  //  Pipe already has reader
@@ -273,7 +275,8 @@ pipe_attach_local_writer (pipe_t *self, client_t *writer)
             zmsg_addstr (msg, self->name);
             zyre_whisper (self->server->zyre, self->remote, &msg);
         }
-        engine_send_event (self->writer, have_writer_event);
+        else
+            engine_send_event (self->reader, have_writer_event);
         return 0;
     }
     return -1;

--- a/src/zpipes_server_engine.h
+++ b/src/zpipes_server_engine.h
@@ -528,22 +528,16 @@ s_client_execute (s_client_t *self, int event)
         self->event = self->next_event;
         self->next_event = NULL_event;
         self->exception = NULL_event;
-        zclock_log ("%6d: %s:",
-            self->unique_id, s_state_name [self->state]);
-        zclock_log ("%6d:     %s",
-            self->unique_id, s_event_name [self->event]);
 
         switch (self->state) {
             case start_state:
                 if (self->event == output_event) {
                     if (!self->exception) {
                         //  lookup or create pipe
-                        zclock_log ("%6d:         $ lookup or create pipe", self->unique_id);
                         lookup_or_create_pipe (&self->client);
                     }
                     if (!self->exception) {
                         //  open pipe writer
-                        zclock_log ("%6d:         $ open pipe writer", self->unique_id);
                         open_pipe_writer (&self->client);
                     }
                     if (!self->exception)
@@ -553,12 +547,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == input_event) {
                     if (!self->exception) {
                         //  lookup or create pipe
-                        zclock_log ("%6d:         $ lookup or create pipe", self->unique_id);
                         lookup_or_create_pipe (&self->client);
                     }
                     if (!self->exception) {
                         //  open pipe reader
-                        zclock_log ("%6d:         $ open pipe reader", self->unique_id);
                         open_pipe_reader (&self->client);
                     }
                     if (!self->exception)
@@ -568,7 +560,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
-                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -588,7 +579,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -596,7 +586,6 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
-                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -604,7 +593,6 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -614,7 +602,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ok_event) {
                     if (!self->exception) {
                         //  send output_ok
-                        zclock_log ("%6d:         $ send OUTPUT_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_OUTPUT_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -627,7 +614,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == error_event) {
                     if (!self->exception) {
                         //  send output_failed
-                        zclock_log ("%6d:         $ send OUTPUT_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_OUTPUT_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -635,7 +621,6 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -654,7 +639,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == write_event) {
                     if (!self->exception) {
                         //  process write request
-                        zclock_log ("%6d:         $ process write request", self->unique_id);
                         process_write_request (&self->client);
                     }
                     if (!self->exception)
@@ -664,7 +648,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == read_event) {
                     if (!self->exception) {
                         //  send invalid
-                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -675,12 +658,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  close pipe writer
-                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
-                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -693,12 +674,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe writer
-                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -706,7 +685,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == reader_dropped_event) {
                     if (!self->exception) {
                         //  close pipe writer
-                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                 }
@@ -714,7 +692,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
-                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -734,7 +711,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -742,7 +718,6 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
-                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -750,7 +725,6 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -760,12 +734,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == have_reader_event) {
                     if (!self->exception) {
                         //  pass data to reader
-                        zclock_log ("%6d:         $ pass data to reader", self->unique_id);
                         pass_data_to_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  send write_ok
-                        zclock_log ("%6d:         $ send WRITE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -778,7 +750,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == wakeup_event) {
                     if (!self->exception) {
                         //  send write_timeout
-                        zclock_log ("%6d:         $ send WRITE_TIMEOUT", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_TIMEOUT);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -791,7 +762,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  send write_failed
-                        zclock_log ("%6d:         $ send WRITE_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -799,12 +769,10 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  close pipe writer
-                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
-                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -817,12 +785,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe writer
-                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -830,7 +796,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == pipe_shut_event) {
                     if (!self->exception) {
                         //  send write_failed
-                        zclock_log ("%6d:         $ send WRITE_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_WRITE_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -843,7 +808,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == reader_dropped_event) {
                     if (!self->exception) {
                         //  close pipe writer
-                        zclock_log ("%6d:         $ close pipe writer", self->unique_id);
                         close_pipe_writer (&self->client);
                     }
                 }
@@ -851,7 +815,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
-                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -873,7 +836,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ok_event) {
                     if (!self->exception) {
                         //  send input_ok
-                        zclock_log ("%6d:         $ send INPUT_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INPUT_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -886,7 +848,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == error_event) {
                     if (!self->exception) {
                         //  send input_failed
-                        zclock_log ("%6d:         $ send INPUT_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INPUT_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -894,7 +855,6 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -913,7 +873,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == read_event) {
                     if (!self->exception) {
                         //  process read request
-                        zclock_log ("%6d:         $ process read request", self->unique_id);
                         process_read_request (&self->client);
                     }
                     if (!self->exception)
@@ -923,7 +882,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == write_event) {
                     if (!self->exception) {
                         //  send invalid
-                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -934,12 +892,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  close pipe reader
-                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
-                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -952,12 +908,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe reader
-                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -965,7 +919,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == writer_dropped_event) {
                     if (!self->exception) {
                         //  close pipe reader
-                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                 }
@@ -973,7 +926,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
-                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -993,7 +945,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1001,7 +952,6 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
-                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1009,7 +959,6 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1019,12 +968,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == have_data_event) {
                     if (!self->exception) {
                         //  collect data to send
-                        zclock_log ("%6d:         $ collect data to send", self->unique_id);
                         collect_data_to_send (&self->client);
                     }
                     if (!self->exception) {
                         //  send read_ok
-                        zclock_log ("%6d:         $ send READ_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1040,7 +987,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == zero_read_event) {
                     if (!self->exception) {
                         //  send read_end
-                        zclock_log ("%6d:         $ send READ_END", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_END);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1053,7 +999,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == pipe_shut_event) {
                     if (!self->exception) {
                         //  send read_end
-                        zclock_log ("%6d:         $ send READ_END", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_END);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1066,7 +1011,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == wakeup_event) {
                     if (!self->exception) {
                         //  send read_timeout
-                        zclock_log ("%6d:         $ send READ_TIMEOUT", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_TIMEOUT);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1079,7 +1023,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == close_event) {
                     if (!self->exception) {
                         //  send read_failed
-                        zclock_log ("%6d:         $ send READ_FAILED", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_FAILED);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1087,12 +1030,10 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  close pipe reader
-                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  send close_ok
-                        zclock_log ("%6d:         $ send CLOSE_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_CLOSE_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1105,12 +1046,10 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  close pipe reader
-                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1118,17 +1057,14 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == writer_dropped_event) {
                     if (!self->exception) {
                         //  close pipe reader
-                        zclock_log ("%6d:         $ close pipe reader", self->unique_id);
                         close_pipe_reader (&self->client);
                     }
                     if (!self->exception) {
                         //  collect data to send
-                        zclock_log ("%6d:         $ collect data to send", self->unique_id);
                         collect_data_to_send (&self->client);
                     }
                     if (!self->exception) {
                         //  send read_ok
-                        zclock_log ("%6d:         $ send READ_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_READ_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1141,7 +1077,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
-                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1163,7 +1098,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
-                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1183,7 +1117,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == expired_event) {
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1191,7 +1124,6 @@ s_client_execute (s_client_t *self, int event)
                     //  Handle unexpected protocol events
                     if (!self->exception) {
                         //  send invalid
-                        zclock_log ("%6d:         $ send INVALID", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_INVALID);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1199,7 +1131,6 @@ s_client_execute (s_client_t *self, int event)
                     }
                     if (!self->exception) {
                         //  terminate
-                        zclock_log ("%6d:         $ terminate", self->unique_id);
                         self->next_event = terminate_event;
                     }
                 }
@@ -1209,7 +1140,6 @@ s_client_execute (s_client_t *self, int event)
                 if (self->event == ping_event) {
                     if (!self->exception) {
                         //  send ping_ok
-                        zclock_log ("%6d:         $ send PING_OK", self->unique_id);
                         zpipes_msg_set_id (self->client.reply, ZPIPES_MSG_PING_OK);
                         zpipes_msg_send (&self->client.reply, self->server->router);
                         self->client.reply = zpipes_msg_new (0);
@@ -1229,8 +1159,6 @@ s_client_execute (s_client_t *self, int event)
         }
         //  If we had an exception event, interrupt normal programming
         if (self->exception) {
-            zclock_log ("%6d:         ! %s",
-                self->unique_id, s_event_name [self->exception]);
             self->next_event = self->exception;
         }
         if (self->next_event == terminate_event) {
@@ -1239,8 +1167,6 @@ s_client_execute (s_client_t *self, int event)
             break;
         }
         else {
-            zclock_log ("%6d:         > %s",
-                self->unique_id, s_state_name [self->state]);
             if (self->next_event == NULL_event)
                 //  Get next valid message from mailbox, if any
                 self->next_event = s_client_filter_mailbox (self);

--- a/src/zpipes_test_cluster.c
+++ b/src/zpipes_test_cluster.c
@@ -20,11 +20,11 @@ int main (void)
     //  Give time for cluster to interconnect
     zclock_sleep (250);
 
-    s_wait ("Open reader");
-    zpipes_client_t *reader = zpipes_client_new ("hosta", "test pipe");
-    
     s_wait ("Open writer");
     zpipes_client_t *writer = zpipes_client_new ("hostb", ">test pipe");
+
+    s_wait ("Open reader");
+    zpipes_client_t *reader = zpipes_client_new ("hosta", "test pipe");
 
     byte buffer [100];
     ssize_t bytes;


### PR DESCRIPTION
Caused by incorrect code sending event to non-existent local thread.
Trivially reproduced in zpipes_test_cluster by opening writer before
reader.

Fixes #46.
