### PR TITLE
Implement process lockfile and run user/group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ doit*
 *.pc
 zpipes_test_cluster.log
 zpipes_test_cluster.trs
+selftest
+core
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_script:
 - cd czmq && git checkout v2.2.0 && cd ..
 - git clone git://github.com/zeromq/zyre.git
 - cd zyre && git checkout v1.0.0 && cd ..
-- for project in libsodium zeromq4-x czmq zyre; do
+- git clone git://github.com/zeromq/libzmtp.git
+- for project in libsodium zeromq4-x czmq zyre libzmtp; do
 -     cd $project
 -     ./autogen.sh
 -     ./configure && make check

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I config
 
-SUBDIRS = src doc
+SUBDIRS = src doc clients
 
-DIST_SUBDIRS = src doc
+DIST_SUBDIRS = src doc clients
 
 EXTRA_DIST =

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -22,7 +22,8 @@ selftest_LDADD = libzbroker_cli.la -lzmtp
 
 libzbroker_cli_la_LDFLAGS = -version-info @LTVER@
 
-TESTS = selftest
+# Selftest isn't working yet
+# TESTS = selftest
 
 # Produce generated models; do this manually in src directory
 code:

--- a/clients/Makefile.am
+++ b/clients/Makefile.am
@@ -1,0 +1,29 @@
+lib_LTLIBRARIES = libzbroker_cli.la
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libzbroker_cli.pc
+
+include_HEADERS = \
+	zpipes_client.h
+
+libzbroker_cli_la_SOURCES = \
+	zchunk.c \
+	zchunk.h \
+	zpipes_msg.h \
+	zpipes_msg.c \
+	zpipes_client.c
+
+AM_CFLAGS = -g
+AM_CPPFLAGS = 
+noinst_PROGRAMS = selftest
+
+selftest_SOURCES = selftest.c
+selftest_LDADD = libzbroker_cli.la -lzmtp
+
+libzbroker_cli_la_LDFLAGS = -version-info @LTVER@
+
+TESTS = selftest
+
+# Produce generated models; do this manually in src directory
+code:
+	gsl -q zpipes_msg.xml

--- a/clients/codec_libzmtp.gsl
+++ b/clients/codec_libzmtp.gsl
@@ -537,8 +537,7 @@ $(class.name)_encode ($(class.name)_t **self_p)
             assert (false);
     }
     //  Now serialize message into the frame
-    byte *data = (byte *) zmalloc (msg_size);
-    zmtp_msg_t *msg = zmtp_msg_new (0, &data, msg_size);
+    zmtp_msg_t *msg = zmtp_msg_new (0, msg_size);
     self->needle = zmtp_msg_data (msg);
 
     //  Each message frame starts with protocol signature

--- a/clients/codec_libzmtp.gsl
+++ b/clients/codec_libzmtp.gsl
@@ -1,0 +1,944 @@
+.template 0
+#   Generates a codec for a protocol specification
+#   Targets raw C without CZMQ, does encode/decode only
+#
+include "zproto_lib.gsl"
+resolve_includes ()
+expand_headers ()
+set_defaults ()
+.endtemplate
+.output "$(class.name).h"
+/*  =========================================================================
+    $(class.name) - $(class.title:)
+    
+    Codec header for $(class.name).
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+    * The XML model used for this code generation: $(filename)
+    * The code generation script that built this file: $(script)
+    ************************************************************************
+.   for class.license
+    $(string.trim (license.):block                                         )
+.   endfor
+    =========================================================================
+*/
+
+#ifndef __$(CLASS.NAME)_H_INCLUDED__
+#define __$(CLASS.NAME)_H_INCLUDED__
+
+/*  These are the $(class.name) messages:
+.for message
+
+    $(NAME) - $(string.trim (.?''):left)
+.   for field
+.       if type = "number"
+        $(name)             $(type) $(size)\
+                                        $(field.?'':)
+.       elsif type = "octets"
+        $(name)             $(type) [$(size)]\
+                                        $(field.?'':)
+.       else
+        $(name)             $(type)     $(field.?'':)
+.       endif
+.   endfor
+.endfor
+*/
+
+.for define
+#define $(CLASS.NAME)_$(DEFINE.NAME:C)      $(value)
+.endfor
+
+.for message
+#define $(CLASS.NAME)_$(MESSAGE.NAME)       $(id)
+.endfor
+.for class.field where type = "octets"
+#define $(CLASS.NAME)_$(FIELD.NAME)_SIZE    $(size)
+.endfor
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  Opaque class structure
+typedef struct _$(class.name)_t $(class.name)_t;
+
+//  @interface
+//  Create a new $(class.name)
+$(class.name)_t *
+    $(class.name)_new (int id);
+
+//  Destroy the $(class.name)
+void
+    $(class.name)_destroy ($(class.name)_t **self_p);
+
+//  Parse a $(class.name) from zmtp_msg_t. Returns a new object, or NULL 
+//  if the message could not be parsed, or was NULL. Nullifies the msg
+//  reference.
+$(class.name)_t *
+    $(class.name)_decode (zmtp_msg_t **msg_p);
+
+//  Encode $(class.name) into a message. Returns a newly created object
+//  or NULL if error. Use when not in control of sending the message.
+//  Destroys the $(class.name)_t instance.
+zmtp_msg_t *
+    $(class.name)_encode ($(class.name)_t **self_p);
+
+//  Receive and parse a $(class.name) from the socket. Returns new object,
+//  or NULL if error. Will block if there's no message waiting.
+CZMQ_EXPORT $(class.name)_t *
+    $(class.name)_recv (zmtp_dealer_t *input);
+
+//  Send the $(class.name) to the output, and destroy it
+CZMQ_EXPORT int
+    $(class.name)_send ($(class.name)_t **self_p, zmtp_dealer_t *output);
+
+.for message
+//  Send the $(message.NAME) to the output in one step
+CZMQ_EXPORT int
+    $(class.name)_send_$(name) (zmtp_dealer_t *output\
+.for field where !defined (value)
+.   if defined (message.has_msg)
+.       echo "E: 'msg' field must be last in the message"
+.   endif
+,
+.   if type = "number"
+        $(ctype) $(name)\
+.   elsif type = "octets"
+        byte *$(name)\
+.   elsif type = "string" | type = "longstr"
+        const char *$(name)\
+.   elsif type = "chunk"
+        zchunk_t *$(name)\
+.   endif
+.endfor
+);
+
+.endfor
+//  Duplicate the $(class.name) message
+$(class.name)_t *
+    $(class.name)_dup ($(class.name)_t *self);
+
+//  Print contents of message to stdout
+void
+    $(class.name)_dump ($(class.name)_t *self);
+
+//  Get the $(class.name) id and printable command
+int
+    $(class.name)_id ($(class.name)_t *self);
+void
+    $(class.name)_set_id ($(class.name)_t *self, int id);
+const char *
+    $(class.name)_command ($(class.name)_t *self);
+
+.for class.field where !defined (value)
+.   if type = "number"
+//  Get/set the $(name) field
+$(ctype)
+    $(class.name)_$(name) ($(class.name)_t *self);
+void
+    $(class.name)_set_$(name) ($(class.name)_t *self, $(ctype) $(name));
+.#
+.   elsif type = "octets"
+//  Get/set the $(name) field
+byte *
+    $(class.name)_$(name) ($(class.name)_t *self);
+void
+    $(class.name)_set_$(name) ($(class.name)_t *self, byte *$(name));
+.#
+.   elsif type = "string" | type = "longstr"
+//  Get/set the $(name) field
+const char *
+    $(class.name)_$(name) ($(class.name)_t *self);
+void
+    $(class.name)_set_$(name) ($(class.name)_t *self, const char *format, ...);
+.#
+.   elsif type = "chunk"
+//  Get a copy of the $(name) field
+z$(type)_t *
+    $(class.name)_$(name) ($(class.name)_t *self);
+//  Get the $(name) field and transfer ownership to caller
+z$(type)_t *
+    $(class.name)_get_$(name) ($(class.name)_t *self);
+//  Set the $(name) field, transferring ownership from caller
+void
+    $(class.name)_set_$(name) ($(class.name)_t *self, z$(type)_t **$(type)_p);
+.#
+.   else
+.       echo "E: unknown type '$(type)' for field '$(name)'"
+.   endif
+
+.endfor
+//  Self test of this class
+int
+    $(class.name)_test (bool verbose);
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+.output "$(class.name).c"
+/*  =========================================================================
+    $(class.name) - $(class.title:)
+
+    Codec class for $(class.name).
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+    * The XML model used for this code generation: $(filename)
+    * The code generation script that built this file: $(script)
+    ************************************************************************
+    
+.   for class.license
+    $(string.trim (license.):block                                         )
+.   endfor
+    =========================================================================
+*/
+
+/*
+@header
+    $(class.name) - $(class.title:)
+@discuss
+@end
+*/
+
+#include <zmtp.h>
+#include "zchunk.h"
+#include "$(class.name).h"
+
+//  Structure of our class
+
+struct _$(class.name)_t {
+    int id;                             //  $(class.name) message ID
+    byte *needle;                       //  Read/write pointer for serialization
+    byte *ceiling;                      //  Valid upper limit for read pointer
+.for class.field
+.   if type = "number"
+    $(ctype) $(name);                   //  $(field.?'':)
+.   elsif type = "octets"
+    byte $(name) [$(size)];             //  $(field.?'':)
+.   elsif type = "string" | type = "longstr"
+    char *$(name);                      //  $(field.?'':)
+.   elsif type = "chunk"
+    z$(type)_t *$(name);                //  $(field.?'':)
+.   endif
+.endfor
+};
+
+//  --------------------------------------------------------------------------
+//  Network data encoding macros
+
+//  Put a block of octets to the frame
+#define PUT_OCTETS(host,size) { \\
+    memcpy (self->needle, (host), size); \\
+    self->needle += size; \\
+}
+
+//  Get a block of octets from the frame
+#define GET_OCTETS(host,size) { \\
+    if (self->needle + size > self->ceiling) \\
+        goto malformed; \\
+    memcpy ((host), self->needle, size); \\
+    self->needle += size; \\
+}
+
+//  Put a 1-byte number to the frame
+#define PUT_NUMBER1(host) { \\
+    *(byte *) self->needle = (host); \\
+    self->needle++; \\
+}
+
+//  Put a 2-byte number to the frame
+#define PUT_NUMBER2(host) { \\
+    self->needle [0] = (byte) (((host) >> 8)  & 255); \\
+    self->needle [1] = (byte) (((host))       & 255); \\
+    self->needle += 2; \\
+}
+
+//  Put a 4-byte number to the frame
+#define PUT_NUMBER4(host) { \\
+    self->needle [0] = (byte) (((host) >> 24) & 255); \\
+    self->needle [1] = (byte) (((host) >> 16) & 255); \\
+    self->needle [2] = (byte) (((host) >> 8)  & 255); \\
+    self->needle [3] = (byte) (((host))       & 255); \\
+    self->needle += 4; \\
+}
+
+//  Put a 8-byte number to the frame
+#define PUT_NUMBER8(host) { \\
+    self->needle [0] = (byte) (((host) >> 56) & 255); \\
+    self->needle [1] = (byte) (((host) >> 48) & 255); \\
+    self->needle [2] = (byte) (((host) >> 40) & 255); \\
+    self->needle [3] = (byte) (((host) >> 32) & 255); \\
+    self->needle [4] = (byte) (((host) >> 24) & 255); \\
+    self->needle [5] = (byte) (((host) >> 16) & 255); \\
+    self->needle [6] = (byte) (((host) >> 8)  & 255); \\
+    self->needle [7] = (byte) (((host))       & 255); \\
+    self->needle += 8; \\
+}
+
+//  Get a 1-byte number from the frame
+#define GET_NUMBER1(host) { \\
+    if (self->needle + 1 > self->ceiling) \\
+        goto malformed; \\
+    (host) = *(byte *) self->needle; \\
+    self->needle++; \\
+}
+
+//  Get a 2-byte number from the frame
+#define GET_NUMBER2(host) { \\
+    if (self->needle + 2 > self->ceiling) \\
+        goto malformed; \\
+    (host) = ((uint16_t) (self->needle [0]) << 8) \\
+           +  (uint16_t) (self->needle [1]); \\
+    self->needle += 2; \\
+}
+
+//  Get a 4-byte number from the frame
+#define GET_NUMBER4(host) { \\
+    if (self->needle + 4 > self->ceiling) \\
+        goto malformed; \\
+    (host) = ((uint32_t) (self->needle [0]) << 24) \\
+           + ((uint32_t) (self->needle [1]) << 16) \\
+           + ((uint32_t) (self->needle [2]) << 8) \\
+           +  (uint32_t) (self->needle [3]); \\
+    self->needle += 4; \\
+}
+
+//  Get a 8-byte number from the frame
+#define GET_NUMBER8(host) { \\
+    if (self->needle + 8 > self->ceiling) \\
+        goto malformed; \\
+    (host) = ((uint64_t) (self->needle [0]) << 56) \\
+           + ((uint64_t) (self->needle [1]) << 48) \\
+           + ((uint64_t) (self->needle [2]) << 40) \\
+           + ((uint64_t) (self->needle [3]) << 32) \\
+           + ((uint64_t) (self->needle [4]) << 24) \\
+           + ((uint64_t) (self->needle [5]) << 16) \\
+           + ((uint64_t) (self->needle [6]) << 8) \\
+           +  (uint64_t) (self->needle [7]); \\
+    self->needle += 8; \\
+}
+
+//  Put a string to the frame
+#define PUT_STRING(host) { \\
+    size_t string_size = strlen (host); \\
+    PUT_NUMBER1 (string_size); \\
+    memcpy (self->needle, (host), string_size); \\
+    self->needle += string_size; \\
+}
+
+//  Get a string from the frame
+#define GET_STRING(host) { \\
+    size_t string_size; \\
+    GET_NUMBER1 (string_size); \\
+    if (self->needle + string_size > (self->ceiling)) \\
+        goto malformed; \\
+    (host) = (char *) malloc (string_size + 1); \\
+    memcpy ((host), self->needle, string_size); \\
+    (host) [string_size] = 0; \\
+    self->needle += string_size; \\
+}
+
+//  Put a long string to the frame
+#define PUT_LONGSTR(host) { \\
+    size_t string_size = strlen (host); \\
+    PUT_NUMBER4 (string_size); \\
+    memcpy (self->needle, (host), string_size); \\
+    self->needle += string_size; \\
+}
+
+//  Get a long string from the frame
+#define GET_LONGSTR(host) { \\
+    size_t string_size; \\
+    GET_NUMBER4 (string_size); \\
+    if (self->needle + string_size > (self->ceiling)) \\
+        goto malformed; \\
+    (host) = (char *) malloc (string_size + 1); \\
+    memcpy ((host), self->needle, string_size); \\
+    (host) [string_size] = 0; \\
+    self->needle += string_size; \\
+}
+
+
+//  --------------------------------------------------------------------------
+//  Create a new $(class.name)
+
+$(class.name)_t *
+$(class.name)_new (int id)
+{
+    $(class.name)_t *self = ($(class.name)_t *) zmalloc (sizeof ($(class.name)_t));
+    self->id = id;
+    return self;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Destroy the $(class.name)
+
+void
+$(class.name)_destroy ($(class.name)_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        $(class.name)_t *self = *self_p;
+
+        //  Free class properties
+.for class.field
+.   if type = "string" | type = "longstr"
+        free (self->$(name));
+.   elsif type = "chunk"
+        z$(type)_destroy (&self->$(name));
+.   endif
+.endfor
+
+        //  Free object itself
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Parse a $(class.name) from zmtp_msg_t. Returns a new object, or NULL if
+//  the message could not be parsed, or was NULL.
+
+$(class.name)_t *
+$(class.name)_decode (zmtp_msg_t **msg_p)
+{
+    assert (msg_p);
+    zmtp_msg_t *msg = *msg_p;
+    if (msg == NULL)
+        return NULL;
+        
+    //  Get and check protocol signature
+    $(class.name)_t *self = $(class.name)_new (0);
+    self->needle = zmtp_msg_data (msg);
+    self->ceiling = self->needle + zmtp_msg_size (msg);
+    uint16_t signature;
+    GET_NUMBER2 (signature);
+    if (signature != (0xAAA0 | $(class.signature)))
+        goto empty;             //  Invalid signature
+
+    //  Get message id and parse per message type
+    GET_NUMBER1 (self->id);
+
+    switch (self->id) {
+.for class.message
+        case $(CLASS.NAME)_$(MESSAGE.NAME):
+.   for field
+.       if type = "number"
+            GET_NUMBER$(size) (self->$(name));
+.           if defined (field.value)
+            if (self->$(name) != $(field.value:))
+                goto malformed;
+.           endif
+.       elsif type = "octets"
+            GET_OCTETS (self->$(name), $(size));
+.       elsif type = "string"
+            GET_STRING (self->$(name));
+.           if defined (field.value)
+            if (strneq (self->$(name), "$(field.value:)"))
+                goto malformed;
+.           endif
+.       elsif type = "longstr"
+            GET_LONGSTR (self->$(name));
+.       elsif type = "chunk"
+            {
+                size_t chunk_size;
+                GET_NUMBER4 (chunk_size);
+                if (self->needle + chunk_size > (self->ceiling))
+                    goto malformed;
+                self->$(name) = zchunk_new (self->needle, chunk_size);
+                self->needle += chunk_size;
+            }
+.       endif
+.   endfor
+            break;
+
+.endfor
+        default:
+            goto malformed;
+    }
+    //  Successful return
+    zmtp_msg_destroy (msg_p);
+    return self;
+
+    //  Error returns
+    malformed:
+        printf ("E: malformed message '%d'\\n", self->id);
+    empty:
+        zmtp_msg_destroy (msg_p);
+        $(class.name)_destroy (&self);
+        return (NULL);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Encode $(class.name) into a message. Returns a newly created object
+//  or NULL if error. Use when not in control of sending the message.
+//  Destroys the $(class.name)_t instance.
+
+zmtp_msg_t *
+$(class.name)_encode ($(class.name)_t **self_p)
+{
+    assert (self_p);
+    assert (*self_p);
+    $(class.name)_t *self = *self_p;
+
+    size_t msg_size = 2 + 1;          //  Signature and message ID
+    switch (self->id) {
+.for class.message
+        case $(CLASS.NAME)_$(MESSAGE.NAME):
+.   for field
+.       if type = "number"
+            //  $(name) is a $(size)-byte integer
+            msg_size += $(size);
+.       elsif type = "octets"
+            //  $(name) is a block of $(size) bytes
+            msg_size += $(size);
+.       elsif type = "string"
+            //  $(name) is a string with 1-byte length
+.           if defined (field.value)
+            msg_size += 1 + strlen ("$(field.value:)");
+.           else
+            msg_size++;       //  Size is one octet
+            if (self->$(name))
+                msg_size += strlen (self->$(name));
+.           endif
+.       elsif type = "longstr"
+            //  $(name) is a string with 4-byte length
+            msg_size += 4;
+            if (self->$(name))
+                msg_size += strlen (self->$(name));
+.       elsif type = "chunk"
+            //  $(name) is a chunk with 4-byte length
+            msg_size += 4;
+            if (self->$(name))
+                msg_size += zchunk_size (self->$(name));
+.       endif
+.   endfor
+            break;
+            
+.endfor
+        default:
+            printf ("E: bad message type '%d', not sent\\n", self->id);
+            //  No recovery, this is a fatal application error
+            assert (false);
+    }
+    //  Now serialize message into the frame
+    byte *data = (byte *) zmalloc (msg_size);
+    zmtp_msg_t *msg = zmtp_msg_new (0, &data, msg_size);
+    self->needle = zmtp_msg_data (msg);
+
+    //  Each message frame starts with protocol signature
+    PUT_NUMBER2 (0xAAA0 | $(class.signature));
+    PUT_NUMBER1 (self->id);
+
+    switch (self->id) {
+.for class.message
+        case $(CLASS.NAME)_$(MESSAGE.NAME):
+.   for field
+.       if type = "number"
+.           if defined (field.value)
+            PUT_NUMBER$(size) ($(field.value:));
+.           else
+            PUT_NUMBER$(size) (self->$(name));
+.           endif
+.       elsif type = "octets"
+            PUT_OCTETS (self->$(name), $(size));
+.       elsif type = "string"
+.           if defined (field.value)
+            PUT_STRING ("$(field.value:)");
+.           else
+            if (self->$(name)) {
+                PUT_STRING (self->$(name));
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+.           endif
+.       elsif type = "longstr"
+            if (self->$(name)) {
+                PUT_LONGSTR (self->$(name));
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty string
+.       elsif type = "chunk"
+            if (self->$(name)) {
+                PUT_NUMBER4 (zchunk_size (self->$(name)));
+                memcpy (self->needle,
+                        zchunk_data (self->$(name)),
+                        zchunk_size (self->$(name)));
+                self->needle += zchunk_size (self->$(name));
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty chunk
+.       endif
+.   endfor
+            break;
+
+.endfor
+    }
+    //  Destroy $(class.name) object
+    $(class.name)_destroy (self_p);
+    return msg;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Receive and parse a $(class.name) from the socket. Returns new object or
+//  NULL if error. Will block if there's no message waiting.
+
+$(class.name)_t *
+$(class.name)_recv (zmtp_dealer_t *input)
+{
+    assert (input);
+    zmtp_msg_t *msg = zmtp_dealer_recv (input);
+    
+    $(class.name)_t * $(class.name) = $(class.name)_decode (&msg);
+    return $(class.name);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the $(class.name) to the socket, and destroy it
+//  Returns 0 if OK, else -1
+
+int
+$(class.name)_send ($(class.name)_t **self_p, zmtp_dealer_t *output)
+{
+    assert (self_p);
+    assert (*self_p);
+    assert (output);
+
+    //  Encode $(class.name) message to a single message
+    zmtp_msg_t *msg = $(class.name)_encode (self_p);
+    if (msg && zmtp_dealer_send (output, msg) == 0)
+        return 0;
+    else {
+        zmtp_msg_destroy (&msg);
+        return -1;              //  Failed to encode, or send
+    }
+}
+
+
+.for message
+//  --------------------------------------------------------------------------
+//  Send the $(message.NAME) to the socket in one step
+
+int
+$(class.name)_send_$(name) (
+    zmtp_dealer_t *output\
+.for field where !defined (value)
+,
+.   if type = "number"
+    $(ctype) $(name)\
+.   elsif type = "octets"
+    byte *$(name)\
+.   elsif type = "string" | type = "longstr"
+    const char *$(name)\
+.   elsif type = "chunk" 
+    zchunk_t *$(name)\
+.   endif
+.endfor
+)
+{
+    $(class.name)_t *self = $(class.name)_new ($(class.NAME)_$(NAME));
+.for field where !defined (value)
+.   if type = "number" | type = "octets" | type = "string" | type = "longstr"
+    $(class.name)_set_$(name) (self, $(name));
+.   elsif type = "chunk"
+    zchunk_t *$(name)_copy = zchunk_dup ($(name));
+    $(class.name)_set_$(name) (self, &$(name)_copy);
+.   endif
+.endfor
+    return $(class.name)_send (&self, output);
+}
+
+
+.endfor
+//  --------------------------------------------------------------------------
+//  Duplicate the $(class.name) message
+
+$(class.name)_t *
+$(class.name)_dup ($(class.name)_t *self)
+{
+    if (!self)
+        return NULL;
+        
+    $(class.name)_t *copy = $(class.name)_new (self->id);
+    switch (self->id) {
+.for class.message
+        case $(CLASS.NAME)_$(MESSAGE.NAME):
+.   for field
+.       if type = "number"
+            copy->$(name) = self->$(name);
+.       elsif type = "octets"
+            memcpy (copy->$(name), self->$(name), $(size));
+.       elsif type = "string" | type = "longstr"
+            copy->$(name) = self->$(name)? strdup (self->$(name)): NULL;
+.       elsif type = "chunk"
+            copy->$(name) = self->$(name)? z$(type)_dup (self->$(name)): NULL;
+.       endif
+.   endfor
+            break;
+
+.endfor
+    }
+    return copy;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Print contents of message to stdout
+
+void
+$(class.name)_dump ($(class.name)_t *self)
+{
+    assert (self);
+    switch (self->id) {
+.for class.message
+        case $(CLASS.NAME)_$(MESSAGE.NAME):
+            puts ("$(MESSAGE.NAME):");
+.   for field
+.       if type = "number"
+.           if defined (field.value)
+            printf ("    $(name)=$(field.value)\\n");
+.           else
+            printf ("    $(name)=%ld\\n", (long) self->$(name));
+.           endif
+.       elsif type = "octets"
+            printf ("    $(name)=[");
+            int $(name)_index;
+            for ($(name)_index = 0; $(name)_index < $(size); $(name)_index++) {
+                if ($(name)_index && ($(name)_index % 4 == 0))
+                    printf ("-");
+                printf ("%02X", self->$(name) [$(name)_index]);
+            }
+        printf ("\\n");
+.       elsif type = "string" | type = "longstr"
+.           if defined (field.value)
+            printf ("    $(name)=$(field.value)\\n");
+.           else
+            if (self->$(name))
+                printf ("    $(name)='%s'\\n", self->$(name));
+            else
+                printf ("    $(name)=\\n");
+.           endif
+.       elsif type = "chunk"
+            printf ("    $(name)={\\n");
+            if (self->$(name))
+                zchunk_print (self->$(name));
+            else
+                printf ("(NULL)\\n");
+            printf ("    }\\n");
+.       endif
+.   endfor
+            break;
+            
+.endfor
+    }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Get/set the $(class.name) id
+
+int
+$(class.name)_id ($(class.name)_t *self)
+{
+    assert (self);
+    return self->id;
+}
+
+void
+$(class.name)_set_id ($(class.name)_t *self, int id)
+{
+    self->id = id;
+}
+
+//  --------------------------------------------------------------------------
+//  Return a printable command string
+
+const char *
+$(class.name)_command ($(class.name)_t *self)
+{
+    assert (self);
+    switch (self->id) {
+.for class.message
+        case $(CLASS.NAME)_$(MESSAGE.NAME):
+            return ("$(MESSAGE.NAME)");
+            break;
+.endfor
+    }
+    return "?";
+}
+
+.for class.field where !defined (value)
+.   if type = "number"
+//  --------------------------------------------------------------------------
+//  Get/set the $(name) field
+
+$(ctype)
+$(class.name)_$(name) ($(class.name)_t *self)
+{
+    assert (self);
+    return self->$(name);
+}
+
+void
+$(class.name)_set_$(name) ($(class.name)_t *self, $(ctype) $(name))
+{
+    assert (self);
+    self->$(name) = $(name);
+}
+
+.   elsif type = "octets"
+//  --------------------------------------------------------------------------
+//  Get/set the $(name) field
+
+byte * 
+$(class.name)_$(name) ($(class.name)_t *self)
+{
+    assert (self);
+    return self->$(name);
+}
+
+void
+$(class.name)_set_$(name) ($(class.name)_t *self, byte *$(name))
+{
+    assert (self);
+    memcpy (self->$(name), $(name), $(size));
+}
+
+.   elsif type = "string" | type = "longstr"
+//  --------------------------------------------------------------------------
+//  Get/set the $(name) field
+
+const char *
+$(class.name)_$(name) ($(class.name)_t *self)
+{
+    assert (self);
+    return self->$(name);
+}
+
+void
+$(class.name)_set_$(name) ($(class.name)_t *self, const char *format, ...)
+{
+    //  Format $(name) from provided arguments
+    assert (self);
+    char formatted [256];
+    va_list argptr;
+    va_start (argptr, format);
+    snprintf (formatted, 255, format, argptr);
+    va_end (argptr);
+    formatted [255] = 0;
+    free (self->$(name));
+    self->$(name) = strdup (formatted);
+}
+
+
+.   elsif type = "chunk"
+//  --------------------------------------------------------------------------
+//  Get the $(name) field without transferring ownership
+
+zchunk_t *
+$(class.name)_$(name) ($(class.name)_t *self)
+{
+    assert (self);
+    return self->$(name);
+}
+
+//  Get the $(name) field and transfer ownership to caller
+
+zchunk_t *
+$(class.name)_get_$(name) ($(class.name)_t *self)
+{
+    zchunk_t *$(name) = self->$(name);
+    self->$(name) = NULL;
+    return $(name);
+}
+
+//  Set the $(name) field, transferring ownership from caller
+
+void
+$(class.name)_set_$(name) ($(class.name)_t *self, zchunk_t **chunk_p)
+{
+    assert (self);
+    assert (chunk_p);
+    zchunk_destroy (&self->$(name));
+    self->$(name) = *chunk_p;
+    *chunk_p = NULL;
+}
+.   endif
+
+.endfor
+
+//  --------------------------------------------------------------------------
+//  Selftest
+
+int
+$(class.name)_test (bool verbose)
+{
+    printf (" * $(class.name): ");
+
+    //  @selftest
+    //  Simple create/destroy test
+    $(class.name)_t *self = $(class.name)_new (0);
+    assert (self);
+    $(class.name)_destroy (&self);
+
+    //  Encode/decode and verify each message type
+    $(class.name)_t *copy;
+.for class.message
+    self = $(class.name)_new ($(CLASS.NAME)_$(MESSAGE.NAME));
+    
+    //  Check that _dup works on empty message
+    copy = $(class.name)_dup (self);
+    assert (copy);
+    $(class.name)_destroy (&copy);
+
+.   for field where !defined (value)
+.       if type = "number"
+    $(class.name)_set_$(name) (self, 123);
+.       elsif type = "octets"
+    byte $(name)_data [$(CLASS.NAME)_$(FIELD.NAME)_SIZE];
+    memset ($(name)_data, 123, $(CLASS.NAME)_$(FIELD.NAME)_SIZE);
+    $(class.name)_set_$(name) (self, $(name)_data);
+.       elsif type = "string" | type = "longstr"
+    $(class.name)_set_$(name) (self, "Life is short but Now lasts for ever");
+.       elsif type = "chunk"
+    z$(type)_t *$(message.name)_$(name) = z$(type)_new ("Captcha Diem", 12);
+    $(class.name)_set_$(name) (self, &$(message.name)_$(name));
+.       endif
+.   endfor
+
+.   for field where !defined (value) 
+.       if type = "number"
+    assert ($(class.name)_$(name) (self) == 123);
+.       elsif type = "octets"
+    assert ($(class.name)_$(name) (self) [0] == 123);
+    assert ($(class.name)_$(name) (self) [$(CLASS.NAME)_$(FIELD.NAME)_SIZE - 1] == 123);
+.       elsif type = "string" | type = "longstr"
+    assert (streq ($(class.name)_$(name) (self), "Life is short but Now lasts for ever"));
+.           elsif type = "chunk"
+    assert (memcmp (zchunk_data ($(class.name)_$(name) (self)), "Captcha Diem", 12) == 0);
+.       endif
+.   endfor
+    $(class.name)_destroy (&self);
+.endfor
+    //  @end
+
+    printf ("OK\\n");
+    return 0;
+}

--- a/clients/libzbroker_cli.pc.in
+++ b/clients/libzbroker_cli.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libzbroker
+Description: ZeroMQ broker project
+Version: @VERSION@
+Requires: libzmq libczmq libzyre
+Libs: -L${libdir} -lzbroker
+Cflags: -I${includedir}

--- a/clients/license.xml
+++ b/clients/license.xml
@@ -1,0 +1,8 @@
+<license>
+Copyright (c) the Contributors as noted in the AUTHORS file.
+This file is part of zbroker, the ZeroMQ broker project.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+</license>

--- a/clients/selftest.c
+++ b/clients/selftest.c
@@ -1,0 +1,32 @@
+/*  =========================================================================
+    selftest - run self tests
+
+    -------------------------------------------------------------------------
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of zbroker, the ZeroMQ broker project.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+#include <zmtp.h>
+#include "zchunk.h"
+#include "zpipes_msg.h"
+#include "zpipes_client.h"
+
+int main (int argc, char *argv [])
+{
+    bool verbose;
+    if (argc == 2 && streq (argv [1], "-v"))
+        verbose = true;
+    else
+        verbose = false;
+
+    printf ("Running self tests...\n");
+    zpipes_msg_test (verbose);
+    zpipes_client_test (verbose);
+    printf ("Tests passed OK\n");
+    return 0;
+}

--- a/clients/zchunk.c
+++ b/clients/zchunk.c
@@ -1,0 +1,393 @@
+/*  =========================================================================
+    zchunk - work with memory chunks
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================*/
+
+/*
+@header
+    The zchunk class works with variable sized blobs. Not as efficient as
+    ØMQ's messages but they do less weirdness and so are easier to understand.
+    The chunk class has methods to read and write chunks from disk.
+@discuss
+@end
+*/
+
+#include <zmtp.h>
+#include "zchunk.h"
+
+//  zchunk_t instances always have this tag as the first 4 octets of
+//  their data, which lets us do runtime object typing & validation.
+#define ZCHUNK_TAG              0x0001cafe
+
+//  Structure of our class
+
+struct _zchunk_t {
+    uint32_t tag;               //  Object tag for runtime detection
+    size_t size;                //  Current size of data part
+    size_t max_size;            //  Maximum allocated size
+    size_t consumed;            //  Amount already consumed
+    byte *data;                 //  Data part follows here
+};
+
+
+//  --------------------------------------------------------------------------
+//  Constructor
+
+zchunk_t *
+zchunk_new (const void *data, size_t size)
+{
+    zchunk_t *self = (zchunk_t *) zmalloc (sizeof (zchunk_t) + size);
+    if (self) {
+        self->tag = ZCHUNK_TAG;
+        self->max_size = size;
+        self->data = (byte *) self + sizeof (zchunk_t);
+        if (data) {
+            self->size = size;
+            memcpy (self->data, data, size);
+        }
+    }
+    return self;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Destroy a chunk
+
+void
+zchunk_destroy (zchunk_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        zchunk_t *self = *self_p;
+        assert (zchunk_is (self));
+        //  If data was reallocated independently, free it independently
+        if (self->data != (byte *) self + sizeof (zchunk_t))
+            free (self->data);
+        self->tag = 0xDeadBeef;
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Resizes chunk max_size as requested; chunk size is set to zero
+
+void
+zchunk_resize (zchunk_t *self, size_t size)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    //  If data was reallocated independently, free it independently
+    if (self->data != (byte *) self + sizeof (zchunk_t))
+        free (self->data);
+
+    self->data = (byte *) zmalloc (size);
+    self->max_size = size;
+    self->size = 0;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return chunk current size
+
+size_t
+zchunk_size (zchunk_t *self)
+{
+    assert (self);
+    assert (zchunk_is (self));
+    return self->size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return chunk max size
+
+size_t
+zchunk_max_size (zchunk_t *self)
+{
+    assert (self);
+    assert (zchunk_is (self));
+    return self->max_size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Return chunk data
+
+byte *
+zchunk_data (zchunk_t *self)
+{
+    assert (self);
+    assert (zchunk_is (self));
+    return self->data;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set chunk data from user-supplied data; truncate if too large. Data may
+//  be null. Returns actual size of chunk
+
+size_t
+zchunk_set (zchunk_t *self, const void *data, size_t size)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    if (size > self->max_size)
+        size = self->max_size;
+    if (data)
+        memcpy (self->data, data, size);
+
+    self->size = size;
+    return size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Fill chunk data from user-supplied octet
+//  Returns actual size of chunk
+
+size_t
+zchunk_fill (zchunk_t *self, byte filler, size_t size)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    if (size > self->max_size)
+        size = self->max_size;
+
+    memset (self->data, filler, size);
+    self->size = size;
+    return size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Append user-supplied data to chunk, return resulting chunk size
+
+size_t
+zchunk_append (zchunk_t *self, const void *data, size_t size)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    if (self->size + size > self->max_size)
+        size = self->max_size - self->size;
+
+    memcpy (self->data + self->size, data, size);
+    self->size += size;
+    return self->size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Copy as much data from 'source' into the chunk as possible; returns the
+//  new size of chunk. If all data from 'source' is used, returns exhausted
+//  on the source chunk. Source can be consumed as many times as needed until
+//  it is exhausted. If source was already exhausted, does not change chunk.
+
+size_t
+zchunk_consume (zchunk_t *self, zchunk_t *source)
+{
+    assert (self);
+    assert (zchunk_is (self));
+    assert (source);
+    assert (zchunk_is (source));
+
+    //  We can take at most this many bytes from source
+    size_t size = source->size - source->consumed;
+
+    //  And we can store at most this many bytes in chunk
+    if (self->size + size > self->max_size)
+        size = self->max_size - self->size;
+
+    memcpy (self->data + self->size, source->data + source->consumed, size);
+    source->consumed += size;
+    self->size += size;
+    return self->size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Returns true if the chunk was exhausted by consume methods, or if the
+//  chunk has a size of zero.
+
+bool
+zchunk_exhausted (zchunk_t *self)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    assert (self->consumed <= self->size);
+    return self->consumed == self->size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Read chunk from an open file descriptor
+
+zchunk_t *
+zchunk_read (FILE *handle, size_t bytes)
+{
+    assert (handle);
+
+    zchunk_t *self = zchunk_new (NULL, bytes);
+    self->size = fread (self->data, 1, bytes, handle);
+    return self;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Write chunk to an open file descriptor
+
+int
+zchunk_write (zchunk_t *self, FILE *handle)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    size_t items = fwrite (self->data, 1, self->size, handle);
+    int rc = (items < self->size)? -1: 0;
+    return rc;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Create copy of chunk, as new chunk object. Returns a fresh zchunk_t
+//  object, or NULL if there was not enough heap memory.
+
+zchunk_t *
+zchunk_dup (zchunk_t *self)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    return zchunk_new (self->data, self->max_size);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Dump chunk to FILE stream, for debugging and tracing.
+
+void
+zchunk_fprint (zchunk_t *self, FILE *file)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    fprintf (file, "--------------------------------------\n");
+    if (!self) {
+        fprintf (file, "NULL");
+        return;
+    }
+    assert (self);
+    int is_bin = 0;
+    uint char_nbr;
+    for (char_nbr = 0; char_nbr < self->size; char_nbr++)
+        if (self->data [char_nbr] < 9 || self->data [char_nbr] > 127)
+            is_bin = 1;
+
+    fprintf (file, "[%03d] ", (int) self->size);
+    for (char_nbr = 0; char_nbr < self->size; char_nbr++) {
+        if (is_bin) {
+            fprintf (file, "%02X", (unsigned char) self->data [char_nbr]);
+            if (char_nbr > 35) {
+                fprintf (file, "...");
+                break;
+            }
+        }
+        else {
+            fprintf (file, "%c", self->data [char_nbr]);
+            if (char_nbr > 70) {
+                fprintf (file, "...");
+                break;
+            }
+        }
+    }
+    fprintf (file, "\n");
+}
+
+
+
+//  --------------------------------------------------------------------------
+//  Dump message to stderr, for debugging and tracing.
+//  See zchunk_fprint for details
+
+void
+zchunk_print (zchunk_t *self)
+{
+    assert (self);
+    assert (zchunk_is (self));
+
+    zchunk_fprint (self, stderr);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Probe the supplied object, and report if it looks like a zchunk_t.
+
+bool
+zchunk_is (void *self)
+{
+    assert (self);
+    return ((zchunk_t *) self)->tag == ZCHUNK_TAG;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Self test of this class
+int
+zchunk_test (bool verbose)
+{
+    printf (" * zchunk: ");
+
+    //  @selftest
+    zchunk_t *chunk = zchunk_new ("1234567890", 10);
+    assert (chunk);
+    assert (zchunk_size (chunk) == 10);
+    assert (memcmp (zchunk_data (chunk), "1234567890", 10) == 0);
+    zchunk_destroy (&chunk);
+
+    chunk = zchunk_new (NULL, 10);
+    zchunk_append (chunk, "12345678", 8);
+    zchunk_append (chunk, "90ABCDEF", 8);
+    zchunk_append (chunk, "GHIJKLMN", 8);
+    assert (memcmp (zchunk_data (chunk), "1234567890", 10) == 0);
+    assert (zchunk_size (chunk) == 10);
+    
+    zchunk_t *copy = zchunk_dup (chunk);
+    assert (memcmp (zchunk_data (copy), "1234567890", 10) == 0);
+    assert (zchunk_size (copy) == 10);
+    zchunk_destroy (&copy);
+    zchunk_destroy (&chunk);
+
+    copy = zchunk_new ("1234567890abcdefghij", 20);
+    chunk = zchunk_new (NULL, 8);
+    zchunk_consume (chunk, copy);
+    assert (!zchunk_exhausted (copy));
+    assert (memcmp (zchunk_data (chunk), "12345678", 8) == 0);
+    zchunk_set (chunk, NULL, 0);
+    zchunk_consume (chunk, copy);
+    assert (!zchunk_exhausted (copy));
+    assert (memcmp (zchunk_data (chunk), "90abcdef", 8) == 0);
+    zchunk_set (chunk, NULL, 0);
+    zchunk_consume (chunk, copy);
+    assert (zchunk_exhausted (copy));
+    assert (zchunk_size (chunk) == 4);
+    assert (memcmp (zchunk_data (chunk), "ghij", 4) == 0);
+    zchunk_destroy (&copy);
+    zchunk_destroy (&chunk);
+    //  @end
+
+    printf ("OK\n");
+    return 0;
+}

--- a/clients/zchunk.h
+++ b/clients/zchunk.h
@@ -1,0 +1,109 @@
+/*  =========================================================================
+    zchunk - work with memory chunks
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of CZMQ, the high-level C binding for 0MQ:
+    http://czmq.zeromq.org.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+#ifndef __ZCHUNK_H_INCLUDED__
+#define __ZCHUNK_H_INCLUDED__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  @interface
+typedef struct _zchunk_t zchunk_t;
+
+//  Create new chunk
+CZMQ_EXPORT zchunk_t *
+    zchunk_new (const void *data, size_t size);
+
+//  Destroy a chunk
+CZMQ_EXPORT void
+    zchunk_destroy (zchunk_t **self_p);
+
+//  Resizes chunk max_size as requested; chunk_cur size is set to zero
+CZMQ_EXPORT void
+    zchunk_resize (zchunk_t *self, size_t size);
+
+//  Return chunk cur size
+CZMQ_EXPORT size_t
+    zchunk_size (zchunk_t *self);
+
+//  Return chunk max size
+CZMQ_EXPORT size_t
+    zchunk_max_size (zchunk_t *self);
+
+//  Return chunk data
+CZMQ_EXPORT byte *
+    zchunk_data (zchunk_t *self);
+
+//  Set chunk data from user-supplied data; truncate if too large. Data may
+//  be null. Returns actual size of chunk
+CZMQ_EXPORT size_t
+    zchunk_set (zchunk_t *self, const void *data, size_t size);
+
+//  Fill chunk data from user-supplied octet
+CZMQ_EXPORT size_t
+    zchunk_fill (zchunk_t *self, byte filler, size_t size);
+
+//  Append user-supplied data to chunk, return resulting chunk size
+CZMQ_EXPORT size_t
+    zchunk_append (zchunk_t *self, const void *data, size_t size);
+
+//  Copy as much data from 'source' into the chunk as possible; returns the
+//  new size of chunk. If all data from 'source' is used, returns exhausted
+//  on the source chunk. Source can be consumed as many times as needed until
+//  it is exhausted. If source was already exhausted, does not change chunk.
+CZMQ_EXPORT size_t
+    zchunk_consume (zchunk_t *self, zchunk_t *source);
+
+//  Returns true if the chunk was exhausted by consume methods, or if the
+//  chunk has a size of zero.
+CZMQ_EXPORT bool
+    zchunk_exhausted (zchunk_t *self);
+
+//  Read chunk from an open file descriptor
+CZMQ_EXPORT zchunk_t *
+    zchunk_read (FILE *handle, size_t bytes);
+    
+//  Write chunk to an open file descriptor
+CZMQ_EXPORT int
+    zchunk_write (zchunk_t *self, FILE *handle);
+
+//  Create copy of chunk, as new chunk object. Returns a fresh zchunk_t
+//  object, or NULL if there was not enough heap memory.
+CZMQ_EXPORT zchunk_t *
+    zchunk_dup (zchunk_t *self);
+
+//  Dump chunk to FILE stream, for debugging and tracing.
+CZMQ_EXPORT void
+    zchunk_fprint (zchunk_t *self, FILE *file);
+
+//  Dump message to stderr, for debugging and tracing.
+//  See zchunk_fprint for details
+CZMQ_EXPORT void
+    zchunk_print (zchunk_t *self);
+
+//  Probe the supplied object, and report if it looks like a zchunk_t.
+CZMQ_EXPORT bool
+    zchunk_is (void *self);
+
+//  Self test of this class
+CZMQ_EXPORT int
+    zchunk_test (bool verbose);
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/clients/zpipes_client.h
+++ b/clients/zpipes_client.h
@@ -1,0 +1,59 @@
+/*  =========================================================================
+    zpipes_client.h - simple API for zpipes client applications
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of zbroker, the ZeroMQ broker project.
+    
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+#ifndef __ZPIPES_CLIENT_H_INCLUDED__
+#define __ZPIPES_CLIENT_H_INCLUDED__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _zpipes_client_t zpipes_client_t;
+
+// @interface
+//  Constructor; open ">pipename" for writing, "pipename" for reading
+CZMQ_EXPORT zpipes_client_t *
+    zpipes_client_new (const char *broker_name, const char *pipe_name);
+
+//  Destructor; closes pipe
+CZMQ_EXPORT void
+    zpipes_client_destroy (zpipes_client_t **self_p);
+
+//  Write chunk of data to pipe; returns number of bytes written, or -1
+//  in case of error, and then sets zpipes_client_error() to EBADF.
+CZMQ_EXPORT ssize_t
+    zpipes_client_write (zpipes_client_t *self,
+                         void *data, size_t size, int timeout);
+
+//  Read chunk of data from pipe. If timeout is non zero, waits at most
+//  that many msecs for data. Returns number of bytes read, or zero if the
+//  pipe was closed by the writer, and no more data is available. On a
+//  timeout or interrupt, returns -1. To get the actual error code, call
+//  zpipes_client_error(), which will be EINTR, EAGAIN, or EBADF.
+CZMQ_EXPORT ssize_t
+    zpipes_client_read (zpipes_client_t *self,
+                        void *data, size_t max_size, int timeout);
+
+//  Returns last error number, if any
+CZMQ_EXPORT int
+    zpipes_client_error (zpipes_client_t *self);
+
+// Self test of this class
+CZMQ_EXPORT void
+    zpipes_client_test (bool verbose);
+// @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/clients/zpipes_msg.c
+++ b/clients/zpipes_msg.c
@@ -472,8 +472,7 @@ zpipes_msg_encode (zpipes_msg_t **self_p)
             assert (false);
     }
     //  Now serialize message into the frame
-    byte *data = (byte *) zmalloc (msg_size);
-    zmtp_msg_t *msg = zmtp_msg_new (0, &data, msg_size);
+    zmtp_msg_t *msg = zmtp_msg_new (0, msg_size);
     self->needle = zmtp_msg_data (msg);
 
     //  Each message frame starts with protocol signature

--- a/clients/zpipes_msg.c
+++ b/clients/zpipes_msg.c
@@ -1,0 +1,1604 @@
+/*  =========================================================================
+    zpipes_msg - ZPIPES protocol
+
+    Codec class for zpipes_msg.
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+    * The XML model used for this code generation: zpipes_msg.xml
+    * The code generation script that built this file: codec_libzmtp
+    ************************************************************************
+    
+    Copyright (c) the Contributors as noted in the AUTHORS file.       
+    This file is part of zbroker, the ZeroMQ broker project.           
+                                                                       
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.           
+    =========================================================================
+*/
+
+/*
+@header
+    zpipes_msg - ZPIPES protocol
+@discuss
+@end
+*/
+
+#include <zmtp.h>
+#include "zchunk.h"
+#include "zpipes_msg.h"
+
+//  Structure of our class
+
+struct _zpipes_msg_t {
+    int id;                             //  zpipes_msg message ID
+    byte *needle;                       //  Read/write pointer for serialization
+    byte *ceiling;                      //  Valid upper limit for read pointer
+    char *pipename;                     //  Name of pipe
+    char *reason;                       //  Reason for failure
+    uint32_t size;                      //  Number of bytes to read
+    uint32_t timeout;                   //  Timeout, msecs, or zero
+    zchunk_t *chunk;                    //  Chunk of data
+};
+
+//  --------------------------------------------------------------------------
+//  Network data encoding macros
+
+//  Put a block of octets to the frame
+#define PUT_OCTETS(host,size) { \
+    memcpy (self->needle, (host), size); \
+    self->needle += size; \
+}
+
+//  Get a block of octets from the frame
+#define GET_OCTETS(host,size) { \
+    if (self->needle + size > self->ceiling) \
+        goto malformed; \
+    memcpy ((host), self->needle, size); \
+    self->needle += size; \
+}
+
+//  Put a 1-byte number to the frame
+#define PUT_NUMBER1(host) { \
+    *(byte *) self->needle = (host); \
+    self->needle++; \
+}
+
+//  Put a 2-byte number to the frame
+#define PUT_NUMBER2(host) { \
+    self->needle [0] = (byte) (((host) >> 8)  & 255); \
+    self->needle [1] = (byte) (((host))       & 255); \
+    self->needle += 2; \
+}
+
+//  Put a 4-byte number to the frame
+#define PUT_NUMBER4(host) { \
+    self->needle [0] = (byte) (((host) >> 24) & 255); \
+    self->needle [1] = (byte) (((host) >> 16) & 255); \
+    self->needle [2] = (byte) (((host) >> 8)  & 255); \
+    self->needle [3] = (byte) (((host))       & 255); \
+    self->needle += 4; \
+}
+
+//  Put a 8-byte number to the frame
+#define PUT_NUMBER8(host) { \
+    self->needle [0] = (byte) (((host) >> 56) & 255); \
+    self->needle [1] = (byte) (((host) >> 48) & 255); \
+    self->needle [2] = (byte) (((host) >> 40) & 255); \
+    self->needle [3] = (byte) (((host) >> 32) & 255); \
+    self->needle [4] = (byte) (((host) >> 24) & 255); \
+    self->needle [5] = (byte) (((host) >> 16) & 255); \
+    self->needle [6] = (byte) (((host) >> 8)  & 255); \
+    self->needle [7] = (byte) (((host))       & 255); \
+    self->needle += 8; \
+}
+
+//  Get a 1-byte number from the frame
+#define GET_NUMBER1(host) { \
+    if (self->needle + 1 > self->ceiling) \
+        goto malformed; \
+    (host) = *(byte *) self->needle; \
+    self->needle++; \
+}
+
+//  Get a 2-byte number from the frame
+#define GET_NUMBER2(host) { \
+    if (self->needle + 2 > self->ceiling) \
+        goto malformed; \
+    (host) = ((uint16_t) (self->needle [0]) << 8) \
+           +  (uint16_t) (self->needle [1]); \
+    self->needle += 2; \
+}
+
+//  Get a 4-byte number from the frame
+#define GET_NUMBER4(host) { \
+    if (self->needle + 4 > self->ceiling) \
+        goto malformed; \
+    (host) = ((uint32_t) (self->needle [0]) << 24) \
+           + ((uint32_t) (self->needle [1]) << 16) \
+           + ((uint32_t) (self->needle [2]) << 8) \
+           +  (uint32_t) (self->needle [3]); \
+    self->needle += 4; \
+}
+
+//  Get a 8-byte number from the frame
+#define GET_NUMBER8(host) { \
+    if (self->needle + 8 > self->ceiling) \
+        goto malformed; \
+    (host) = ((uint64_t) (self->needle [0]) << 56) \
+           + ((uint64_t) (self->needle [1]) << 48) \
+           + ((uint64_t) (self->needle [2]) << 40) \
+           + ((uint64_t) (self->needle [3]) << 32) \
+           + ((uint64_t) (self->needle [4]) << 24) \
+           + ((uint64_t) (self->needle [5]) << 16) \
+           + ((uint64_t) (self->needle [6]) << 8) \
+           +  (uint64_t) (self->needle [7]); \
+    self->needle += 8; \
+}
+
+//  Put a string to the frame
+#define PUT_STRING(host) { \
+    size_t string_size = strlen (host); \
+    PUT_NUMBER1 (string_size); \
+    memcpy (self->needle, (host), string_size); \
+    self->needle += string_size; \
+}
+
+//  Get a string from the frame
+#define GET_STRING(host) { \
+    size_t string_size; \
+    GET_NUMBER1 (string_size); \
+    if (self->needle + string_size > (self->ceiling)) \
+        goto malformed; \
+    (host) = (char *) malloc (string_size + 1); \
+    memcpy ((host), self->needle, string_size); \
+    (host) [string_size] = 0; \
+    self->needle += string_size; \
+}
+
+//  Put a long string to the frame
+#define PUT_LONGSTR(host) { \
+    size_t string_size = strlen (host); \
+    PUT_NUMBER4 (string_size); \
+    memcpy (self->needle, (host), string_size); \
+    self->needle += string_size; \
+}
+
+//  Get a long string from the frame
+#define GET_LONGSTR(host) { \
+    size_t string_size; \
+    GET_NUMBER4 (string_size); \
+    if (self->needle + string_size > (self->ceiling)) \
+        goto malformed; \
+    (host) = (char *) malloc (string_size + 1); \
+    memcpy ((host), self->needle, string_size); \
+    (host) [string_size] = 0; \
+    self->needle += string_size; \
+}
+
+
+//  --------------------------------------------------------------------------
+//  Create a new zpipes_msg
+
+zpipes_msg_t *
+zpipes_msg_new (int id)
+{
+    zpipes_msg_t *self = (zpipes_msg_t *) zmalloc (sizeof (zpipes_msg_t));
+    self->id = id;
+    return self;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Destroy the zpipes_msg
+
+void
+zpipes_msg_destroy (zpipes_msg_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        zpipes_msg_t *self = *self_p;
+
+        //  Free class properties
+        free (self->pipename);
+        free (self->reason);
+        zchunk_destroy (&self->chunk);
+
+        //  Free object itself
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Parse a zpipes_msg from zmtp_msg_t. Returns a new object, or NULL if
+//  the message could not be parsed, or was NULL.
+
+zpipes_msg_t *
+zpipes_msg_decode (zmtp_msg_t **msg_p)
+{
+    assert (msg_p);
+    zmtp_msg_t *msg = *msg_p;
+    if (msg == NULL)
+        return NULL;
+        
+    //  Get and check protocol signature
+    zpipes_msg_t *self = zpipes_msg_new (0);
+    self->needle = zmtp_msg_data (msg);
+    self->ceiling = self->needle + zmtp_msg_size (msg);
+    uint16_t signature;
+    GET_NUMBER2 (signature);
+    if (signature != (0xAAA0 | 0))
+        goto empty;             //  Invalid signature
+
+    //  Get message id and parse per message type
+    GET_NUMBER1 (self->id);
+
+    switch (self->id) {
+        case ZPIPES_MSG_INPUT:
+            GET_STRING (self->pipename);
+            break;
+
+        case ZPIPES_MSG_INPUT_OK:
+            break;
+
+        case ZPIPES_MSG_INPUT_FAILED:
+            GET_STRING (self->reason);
+            break;
+
+        case ZPIPES_MSG_OUTPUT:
+            GET_STRING (self->pipename);
+            break;
+
+        case ZPIPES_MSG_OUTPUT_OK:
+            break;
+
+        case ZPIPES_MSG_OUTPUT_FAILED:
+            GET_STRING (self->reason);
+            break;
+
+        case ZPIPES_MSG_READ:
+            GET_NUMBER4 (self->size);
+            GET_NUMBER4 (self->timeout);
+            break;
+
+        case ZPIPES_MSG_READ_OK:
+            {
+                size_t chunk_size;
+                GET_NUMBER4 (chunk_size);
+                if (self->needle + chunk_size > (self->ceiling))
+                    goto malformed;
+                self->chunk = zchunk_new (self->needle, chunk_size);
+                self->needle += chunk_size;
+            }
+            break;
+
+        case ZPIPES_MSG_READ_END:
+            break;
+
+        case ZPIPES_MSG_READ_TIMEOUT:
+            break;
+
+        case ZPIPES_MSG_READ_FAILED:
+            GET_STRING (self->reason);
+            break;
+
+        case ZPIPES_MSG_WRITE:
+            {
+                size_t chunk_size;
+                GET_NUMBER4 (chunk_size);
+                if (self->needle + chunk_size > (self->ceiling))
+                    goto malformed;
+                self->chunk = zchunk_new (self->needle, chunk_size);
+                self->needle += chunk_size;
+            }
+            GET_NUMBER4 (self->timeout);
+            break;
+
+        case ZPIPES_MSG_WRITE_OK:
+            break;
+
+        case ZPIPES_MSG_WRITE_TIMEOUT:
+            break;
+
+        case ZPIPES_MSG_WRITE_FAILED:
+            GET_STRING (self->reason);
+            break;
+
+        case ZPIPES_MSG_CLOSE:
+            break;
+
+        case ZPIPES_MSG_CLOSE_OK:
+            break;
+
+        case ZPIPES_MSG_CLOSE_FAILED:
+            GET_STRING (self->reason);
+            break;
+
+        case ZPIPES_MSG_PING:
+            break;
+
+        case ZPIPES_MSG_PING_OK:
+            break;
+
+        case ZPIPES_MSG_INVALID:
+            break;
+
+        default:
+            goto malformed;
+    }
+    //  Successful return
+    zmtp_msg_destroy (msg_p);
+    return self;
+
+    //  Error returns
+    malformed:
+        printf ("E: malformed message '%d'\n", self->id);
+    empty:
+        zmtp_msg_destroy (msg_p);
+        zpipes_msg_destroy (&self);
+        return (NULL);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Encode zpipes_msg into a message. Returns a newly created object
+//  or NULL if error. Use when not in control of sending the message.
+//  Destroys the zpipes_msg_t instance.
+
+zmtp_msg_t *
+zpipes_msg_encode (zpipes_msg_t **self_p)
+{
+    assert (self_p);
+    assert (*self_p);
+    zpipes_msg_t *self = *self_p;
+
+    size_t msg_size = 2 + 1;          //  Signature and message ID
+    switch (self->id) {
+        case ZPIPES_MSG_INPUT:
+            //  pipename is a string with 1-byte length
+            msg_size++;       //  Size is one octet
+            if (self->pipename)
+                msg_size += strlen (self->pipename);
+            break;
+            
+        case ZPIPES_MSG_INPUT_OK:
+            break;
+            
+        case ZPIPES_MSG_INPUT_FAILED:
+            //  reason is a string with 1-byte length
+            msg_size++;       //  Size is one octet
+            if (self->reason)
+                msg_size += strlen (self->reason);
+            break;
+            
+        case ZPIPES_MSG_OUTPUT:
+            //  pipename is a string with 1-byte length
+            msg_size++;       //  Size is one octet
+            if (self->pipename)
+                msg_size += strlen (self->pipename);
+            break;
+            
+        case ZPIPES_MSG_OUTPUT_OK:
+            break;
+            
+        case ZPIPES_MSG_OUTPUT_FAILED:
+            //  reason is a string with 1-byte length
+            msg_size++;       //  Size is one octet
+            if (self->reason)
+                msg_size += strlen (self->reason);
+            break;
+            
+        case ZPIPES_MSG_READ:
+            //  size is a 4-byte integer
+            msg_size += 4;
+            //  timeout is a 4-byte integer
+            msg_size += 4;
+            break;
+            
+        case ZPIPES_MSG_READ_OK:
+            //  chunk is a chunk with 4-byte length
+            msg_size += 4;
+            if (self->chunk)
+                msg_size += zchunk_size (self->chunk);
+            break;
+            
+        case ZPIPES_MSG_READ_END:
+            break;
+            
+        case ZPIPES_MSG_READ_TIMEOUT:
+            break;
+            
+        case ZPIPES_MSG_READ_FAILED:
+            //  reason is a string with 1-byte length
+            msg_size++;       //  Size is one octet
+            if (self->reason)
+                msg_size += strlen (self->reason);
+            break;
+            
+        case ZPIPES_MSG_WRITE:
+            //  chunk is a chunk with 4-byte length
+            msg_size += 4;
+            if (self->chunk)
+                msg_size += zchunk_size (self->chunk);
+            //  timeout is a 4-byte integer
+            msg_size += 4;
+            break;
+            
+        case ZPIPES_MSG_WRITE_OK:
+            break;
+            
+        case ZPIPES_MSG_WRITE_TIMEOUT:
+            break;
+            
+        case ZPIPES_MSG_WRITE_FAILED:
+            //  reason is a string with 1-byte length
+            msg_size++;       //  Size is one octet
+            if (self->reason)
+                msg_size += strlen (self->reason);
+            break;
+            
+        case ZPIPES_MSG_CLOSE:
+            break;
+            
+        case ZPIPES_MSG_CLOSE_OK:
+            break;
+            
+        case ZPIPES_MSG_CLOSE_FAILED:
+            //  reason is a string with 1-byte length
+            msg_size++;       //  Size is one octet
+            if (self->reason)
+                msg_size += strlen (self->reason);
+            break;
+            
+        case ZPIPES_MSG_PING:
+            break;
+            
+        case ZPIPES_MSG_PING_OK:
+            break;
+            
+        case ZPIPES_MSG_INVALID:
+            break;
+            
+        default:
+            printf ("E: bad message type '%d', not sent\n", self->id);
+            //  No recovery, this is a fatal application error
+            assert (false);
+    }
+    //  Now serialize message into the frame
+    byte *data = (byte *) zmalloc (msg_size);
+    zmtp_msg_t *msg = zmtp_msg_new (0, &data, msg_size);
+    self->needle = zmtp_msg_data (msg);
+
+    //  Each message frame starts with protocol signature
+    PUT_NUMBER2 (0xAAA0 | 0);
+    PUT_NUMBER1 (self->id);
+
+    switch (self->id) {
+        case ZPIPES_MSG_INPUT:
+            if (self->pipename) {
+                PUT_STRING (self->pipename);
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+            break;
+
+        case ZPIPES_MSG_INPUT_OK:
+            break;
+
+        case ZPIPES_MSG_INPUT_FAILED:
+            if (self->reason) {
+                PUT_STRING (self->reason);
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+            break;
+
+        case ZPIPES_MSG_OUTPUT:
+            if (self->pipename) {
+                PUT_STRING (self->pipename);
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+            break;
+
+        case ZPIPES_MSG_OUTPUT_OK:
+            break;
+
+        case ZPIPES_MSG_OUTPUT_FAILED:
+            if (self->reason) {
+                PUT_STRING (self->reason);
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+            break;
+
+        case ZPIPES_MSG_READ:
+            PUT_NUMBER4 (self->size);
+            PUT_NUMBER4 (self->timeout);
+            break;
+
+        case ZPIPES_MSG_READ_OK:
+            if (self->chunk) {
+                PUT_NUMBER4 (zchunk_size (self->chunk));
+                memcpy (self->needle,
+                        zchunk_data (self->chunk),
+                        zchunk_size (self->chunk));
+                self->needle += zchunk_size (self->chunk);
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty chunk
+            break;
+
+        case ZPIPES_MSG_READ_END:
+            break;
+
+        case ZPIPES_MSG_READ_TIMEOUT:
+            break;
+
+        case ZPIPES_MSG_READ_FAILED:
+            if (self->reason) {
+                PUT_STRING (self->reason);
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+            break;
+
+        case ZPIPES_MSG_WRITE:
+            if (self->chunk) {
+                PUT_NUMBER4 (zchunk_size (self->chunk));
+                memcpy (self->needle,
+                        zchunk_data (self->chunk),
+                        zchunk_size (self->chunk));
+                self->needle += zchunk_size (self->chunk);
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty chunk
+            PUT_NUMBER4 (self->timeout);
+            break;
+
+        case ZPIPES_MSG_WRITE_OK:
+            break;
+
+        case ZPIPES_MSG_WRITE_TIMEOUT:
+            break;
+
+        case ZPIPES_MSG_WRITE_FAILED:
+            if (self->reason) {
+                PUT_STRING (self->reason);
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+            break;
+
+        case ZPIPES_MSG_CLOSE:
+            break;
+
+        case ZPIPES_MSG_CLOSE_OK:
+            break;
+
+        case ZPIPES_MSG_CLOSE_FAILED:
+            if (self->reason) {
+                PUT_STRING (self->reason);
+            }
+            else
+                PUT_NUMBER1 (0);    //  Empty string
+            break;
+
+        case ZPIPES_MSG_PING:
+            break;
+
+        case ZPIPES_MSG_PING_OK:
+            break;
+
+        case ZPIPES_MSG_INVALID:
+            break;
+
+    }
+    //  Destroy zpipes_msg object
+    zpipes_msg_destroy (self_p);
+    return msg;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Receive and parse a zpipes_msg from the socket. Returns new object or
+//  NULL if error. Will block if there's no message waiting.
+
+zpipes_msg_t *
+zpipes_msg_recv (zmtp_dealer_t *input)
+{
+    assert (input);
+    zmtp_msg_t *msg = zmtp_dealer_recv (input);
+    
+    zpipes_msg_t * zpipes_msg = zpipes_msg_decode (&msg);
+    return zpipes_msg;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the zpipes_msg to the socket, and destroy it
+//  Returns 0 if OK, else -1
+
+int
+zpipes_msg_send (zpipes_msg_t **self_p, zmtp_dealer_t *output)
+{
+    assert (self_p);
+    assert (*self_p);
+    assert (output);
+
+    //  Encode zpipes_msg message to a single message
+    zmtp_msg_t *msg = zpipes_msg_encode (self_p);
+    if (msg && zmtp_dealer_send (output, msg) == 0)
+        return 0;
+    else {
+        zmtp_msg_destroy (&msg);
+        return -1;              //  Failed to encode, or send
+    }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the INPUT to the socket in one step
+
+int
+zpipes_msg_send_input (
+    zmtp_dealer_t *output,
+    const char *pipename)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_INPUT);
+    zpipes_msg_set_pipename (self, pipename);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the INPUT_OK to the socket in one step
+
+int
+zpipes_msg_send_input_ok (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_INPUT_OK);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the INPUT_FAILED to the socket in one step
+
+int
+zpipes_msg_send_input_failed (
+    zmtp_dealer_t *output,
+    const char *reason)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_INPUT_FAILED);
+    zpipes_msg_set_reason (self, reason);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the OUTPUT to the socket in one step
+
+int
+zpipes_msg_send_output (
+    zmtp_dealer_t *output,
+    const char *pipename)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_OUTPUT);
+    zpipes_msg_set_pipename (self, pipename);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the OUTPUT_OK to the socket in one step
+
+int
+zpipes_msg_send_output_ok (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_OUTPUT_OK);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the OUTPUT_FAILED to the socket in one step
+
+int
+zpipes_msg_send_output_failed (
+    zmtp_dealer_t *output,
+    const char *reason)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_OUTPUT_FAILED);
+    zpipes_msg_set_reason (self, reason);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the READ to the socket in one step
+
+int
+zpipes_msg_send_read (
+    zmtp_dealer_t *output,
+    uint32_t size,
+    uint32_t timeout)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_READ);
+    zpipes_msg_set_size (self, size);
+    zpipes_msg_set_timeout (self, timeout);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the READ_OK to the socket in one step
+
+int
+zpipes_msg_send_read_ok (
+    zmtp_dealer_t *output,
+    zchunk_t *chunk)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_READ_OK);
+    zchunk_t *chunk_copy = zchunk_dup (chunk);
+    zpipes_msg_set_chunk (self, &chunk_copy);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the READ_END to the socket in one step
+
+int
+zpipes_msg_send_read_end (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_READ_END);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the READ_TIMEOUT to the socket in one step
+
+int
+zpipes_msg_send_read_timeout (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_READ_TIMEOUT);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the READ_FAILED to the socket in one step
+
+int
+zpipes_msg_send_read_failed (
+    zmtp_dealer_t *output,
+    const char *reason)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_READ_FAILED);
+    zpipes_msg_set_reason (self, reason);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the WRITE to the socket in one step
+
+int
+zpipes_msg_send_write (
+    zmtp_dealer_t *output,
+    zchunk_t *chunk,
+    uint32_t timeout)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_WRITE);
+    zchunk_t *chunk_copy = zchunk_dup (chunk);
+    zpipes_msg_set_chunk (self, &chunk_copy);
+    zpipes_msg_set_timeout (self, timeout);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the WRITE_OK to the socket in one step
+
+int
+zpipes_msg_send_write_ok (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_WRITE_OK);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the WRITE_TIMEOUT to the socket in one step
+
+int
+zpipes_msg_send_write_timeout (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_WRITE_TIMEOUT);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the WRITE_FAILED to the socket in one step
+
+int
+zpipes_msg_send_write_failed (
+    zmtp_dealer_t *output,
+    const char *reason)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_WRITE_FAILED);
+    zpipes_msg_set_reason (self, reason);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the CLOSE to the socket in one step
+
+int
+zpipes_msg_send_close (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_CLOSE);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the CLOSE_OK to the socket in one step
+
+int
+zpipes_msg_send_close_ok (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_CLOSE_OK);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the CLOSE_FAILED to the socket in one step
+
+int
+zpipes_msg_send_close_failed (
+    zmtp_dealer_t *output,
+    const char *reason)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_CLOSE_FAILED);
+    zpipes_msg_set_reason (self, reason);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the PING to the socket in one step
+
+int
+zpipes_msg_send_ping (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_PING);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the PING_OK to the socket in one step
+
+int
+zpipes_msg_send_ping_ok (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_PING_OK);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Send the INVALID to the socket in one step
+
+int
+zpipes_msg_send_invalid (
+    zmtp_dealer_t *output)
+{
+    zpipes_msg_t *self = zpipes_msg_new (ZPIPES_MSG_INVALID);
+    return zpipes_msg_send (&self, output);
+}
+
+
+//  --------------------------------------------------------------------------
+//  Duplicate the zpipes_msg message
+
+zpipes_msg_t *
+zpipes_msg_dup (zpipes_msg_t *self)
+{
+    if (!self)
+        return NULL;
+        
+    zpipes_msg_t *copy = zpipes_msg_new (self->id);
+    switch (self->id) {
+        case ZPIPES_MSG_INPUT:
+            copy->pipename = self->pipename? strdup (self->pipename): NULL;
+            break;
+
+        case ZPIPES_MSG_INPUT_OK:
+            break;
+
+        case ZPIPES_MSG_INPUT_FAILED:
+            copy->reason = self->reason? strdup (self->reason): NULL;
+            break;
+
+        case ZPIPES_MSG_OUTPUT:
+            copy->pipename = self->pipename? strdup (self->pipename): NULL;
+            break;
+
+        case ZPIPES_MSG_OUTPUT_OK:
+            break;
+
+        case ZPIPES_MSG_OUTPUT_FAILED:
+            copy->reason = self->reason? strdup (self->reason): NULL;
+            break;
+
+        case ZPIPES_MSG_READ:
+            copy->size = self->size;
+            copy->timeout = self->timeout;
+            break;
+
+        case ZPIPES_MSG_READ_OK:
+            copy->chunk = self->chunk? zchunk_dup (self->chunk): NULL;
+            break;
+
+        case ZPIPES_MSG_READ_END:
+            break;
+
+        case ZPIPES_MSG_READ_TIMEOUT:
+            break;
+
+        case ZPIPES_MSG_READ_FAILED:
+            copy->reason = self->reason? strdup (self->reason): NULL;
+            break;
+
+        case ZPIPES_MSG_WRITE:
+            copy->chunk = self->chunk? zchunk_dup (self->chunk): NULL;
+            copy->timeout = self->timeout;
+            break;
+
+        case ZPIPES_MSG_WRITE_OK:
+            break;
+
+        case ZPIPES_MSG_WRITE_TIMEOUT:
+            break;
+
+        case ZPIPES_MSG_WRITE_FAILED:
+            copy->reason = self->reason? strdup (self->reason): NULL;
+            break;
+
+        case ZPIPES_MSG_CLOSE:
+            break;
+
+        case ZPIPES_MSG_CLOSE_OK:
+            break;
+
+        case ZPIPES_MSG_CLOSE_FAILED:
+            copy->reason = self->reason? strdup (self->reason): NULL;
+            break;
+
+        case ZPIPES_MSG_PING:
+            break;
+
+        case ZPIPES_MSG_PING_OK:
+            break;
+
+        case ZPIPES_MSG_INVALID:
+            break;
+
+    }
+    return copy;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Print contents of message to stdout
+
+void
+zpipes_msg_dump (zpipes_msg_t *self)
+{
+    assert (self);
+    switch (self->id) {
+        case ZPIPES_MSG_INPUT:
+            puts ("INPUT:");
+            if (self->pipename)
+                printf ("    pipename='%s'\n", self->pipename);
+            else
+                printf ("    pipename=\n");
+            break;
+            
+        case ZPIPES_MSG_INPUT_OK:
+            puts ("INPUT_OK:");
+            break;
+            
+        case ZPIPES_MSG_INPUT_FAILED:
+            puts ("INPUT_FAILED:");
+            if (self->reason)
+                printf ("    reason='%s'\n", self->reason);
+            else
+                printf ("    reason=\n");
+            break;
+            
+        case ZPIPES_MSG_OUTPUT:
+            puts ("OUTPUT:");
+            if (self->pipename)
+                printf ("    pipename='%s'\n", self->pipename);
+            else
+                printf ("    pipename=\n");
+            break;
+            
+        case ZPIPES_MSG_OUTPUT_OK:
+            puts ("OUTPUT_OK:");
+            break;
+            
+        case ZPIPES_MSG_OUTPUT_FAILED:
+            puts ("OUTPUT_FAILED:");
+            if (self->reason)
+                printf ("    reason='%s'\n", self->reason);
+            else
+                printf ("    reason=\n");
+            break;
+            
+        case ZPIPES_MSG_READ:
+            puts ("READ:");
+            printf ("    size=%ld\n", (long) self->size);
+            printf ("    timeout=%ld\n", (long) self->timeout);
+            break;
+            
+        case ZPIPES_MSG_READ_OK:
+            puts ("READ_OK:");
+            printf ("    chunk={\n");
+            if (self->chunk)
+                zchunk_print (self->chunk);
+            else
+                printf ("(NULL)\n");
+            printf ("    }\n");
+            break;
+            
+        case ZPIPES_MSG_READ_END:
+            puts ("READ_END:");
+            break;
+            
+        case ZPIPES_MSG_READ_TIMEOUT:
+            puts ("READ_TIMEOUT:");
+            break;
+            
+        case ZPIPES_MSG_READ_FAILED:
+            puts ("READ_FAILED:");
+            if (self->reason)
+                printf ("    reason='%s'\n", self->reason);
+            else
+                printf ("    reason=\n");
+            break;
+            
+        case ZPIPES_MSG_WRITE:
+            puts ("WRITE:");
+            printf ("    chunk={\n");
+            if (self->chunk)
+                zchunk_print (self->chunk);
+            else
+                printf ("(NULL)\n");
+            printf ("    }\n");
+            printf ("    timeout=%ld\n", (long) self->timeout);
+            break;
+            
+        case ZPIPES_MSG_WRITE_OK:
+            puts ("WRITE_OK:");
+            break;
+            
+        case ZPIPES_MSG_WRITE_TIMEOUT:
+            puts ("WRITE_TIMEOUT:");
+            break;
+            
+        case ZPIPES_MSG_WRITE_FAILED:
+            puts ("WRITE_FAILED:");
+            if (self->reason)
+                printf ("    reason='%s'\n", self->reason);
+            else
+                printf ("    reason=\n");
+            break;
+            
+        case ZPIPES_MSG_CLOSE:
+            puts ("CLOSE:");
+            break;
+            
+        case ZPIPES_MSG_CLOSE_OK:
+            puts ("CLOSE_OK:");
+            break;
+            
+        case ZPIPES_MSG_CLOSE_FAILED:
+            puts ("CLOSE_FAILED:");
+            if (self->reason)
+                printf ("    reason='%s'\n", self->reason);
+            else
+                printf ("    reason=\n");
+            break;
+            
+        case ZPIPES_MSG_PING:
+            puts ("PING:");
+            break;
+            
+        case ZPIPES_MSG_PING_OK:
+            puts ("PING_OK:");
+            break;
+            
+        case ZPIPES_MSG_INVALID:
+            puts ("INVALID:");
+            break;
+            
+    }
+}
+
+
+//  --------------------------------------------------------------------------
+//  Get/set the zpipes_msg id
+
+int
+zpipes_msg_id (zpipes_msg_t *self)
+{
+    assert (self);
+    return self->id;
+}
+
+void
+zpipes_msg_set_id (zpipes_msg_t *self, int id)
+{
+    self->id = id;
+}
+
+//  --------------------------------------------------------------------------
+//  Return a printable command string
+
+const char *
+zpipes_msg_command (zpipes_msg_t *self)
+{
+    assert (self);
+    switch (self->id) {
+        case ZPIPES_MSG_INPUT:
+            return ("INPUT");
+            break;
+        case ZPIPES_MSG_INPUT_OK:
+            return ("INPUT_OK");
+            break;
+        case ZPIPES_MSG_INPUT_FAILED:
+            return ("INPUT_FAILED");
+            break;
+        case ZPIPES_MSG_OUTPUT:
+            return ("OUTPUT");
+            break;
+        case ZPIPES_MSG_OUTPUT_OK:
+            return ("OUTPUT_OK");
+            break;
+        case ZPIPES_MSG_OUTPUT_FAILED:
+            return ("OUTPUT_FAILED");
+            break;
+        case ZPIPES_MSG_READ:
+            return ("READ");
+            break;
+        case ZPIPES_MSG_READ_OK:
+            return ("READ_OK");
+            break;
+        case ZPIPES_MSG_READ_END:
+            return ("READ_END");
+            break;
+        case ZPIPES_MSG_READ_TIMEOUT:
+            return ("READ_TIMEOUT");
+            break;
+        case ZPIPES_MSG_READ_FAILED:
+            return ("READ_FAILED");
+            break;
+        case ZPIPES_MSG_WRITE:
+            return ("WRITE");
+            break;
+        case ZPIPES_MSG_WRITE_OK:
+            return ("WRITE_OK");
+            break;
+        case ZPIPES_MSG_WRITE_TIMEOUT:
+            return ("WRITE_TIMEOUT");
+            break;
+        case ZPIPES_MSG_WRITE_FAILED:
+            return ("WRITE_FAILED");
+            break;
+        case ZPIPES_MSG_CLOSE:
+            return ("CLOSE");
+            break;
+        case ZPIPES_MSG_CLOSE_OK:
+            return ("CLOSE_OK");
+            break;
+        case ZPIPES_MSG_CLOSE_FAILED:
+            return ("CLOSE_FAILED");
+            break;
+        case ZPIPES_MSG_PING:
+            return ("PING");
+            break;
+        case ZPIPES_MSG_PING_OK:
+            return ("PING_OK");
+            break;
+        case ZPIPES_MSG_INVALID:
+            return ("INVALID");
+            break;
+    }
+    return "?";
+}
+
+//  --------------------------------------------------------------------------
+//  Get/set the pipename field
+
+const char *
+zpipes_msg_pipename (zpipes_msg_t *self)
+{
+    assert (self);
+    return self->pipename;
+}
+
+void
+zpipes_msg_set_pipename (zpipes_msg_t *self, const char *format, ...)
+{
+    //  Format pipename from provided arguments
+    assert (self);
+    char formatted [256];
+    va_list argptr;
+    va_start (argptr, format);
+    snprintf (formatted, 255, format, argptr);
+    va_end (argptr);
+    formatted [255] = 0;
+    free (self->pipename);
+    self->pipename = strdup (formatted);
+}
+
+
+
+//  --------------------------------------------------------------------------
+//  Get/set the reason field
+
+const char *
+zpipes_msg_reason (zpipes_msg_t *self)
+{
+    assert (self);
+    return self->reason;
+}
+
+void
+zpipes_msg_set_reason (zpipes_msg_t *self, const char *format, ...)
+{
+    //  Format reason from provided arguments
+    assert (self);
+    char formatted [256];
+    va_list argptr;
+    va_start (argptr, format);
+    snprintf (formatted, 255, format, argptr);
+    va_end (argptr);
+    formatted [255] = 0;
+    free (self->reason);
+    self->reason = strdup (formatted);
+}
+
+
+
+//  --------------------------------------------------------------------------
+//  Get/set the size field
+
+uint32_t
+zpipes_msg_size (zpipes_msg_t *self)
+{
+    assert (self);
+    return self->size;
+}
+
+void
+zpipes_msg_set_size (zpipes_msg_t *self, uint32_t size)
+{
+    assert (self);
+    self->size = size;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Get/set the timeout field
+
+uint32_t
+zpipes_msg_timeout (zpipes_msg_t *self)
+{
+    assert (self);
+    return self->timeout;
+}
+
+void
+zpipes_msg_set_timeout (zpipes_msg_t *self, uint32_t timeout)
+{
+    assert (self);
+    self->timeout = timeout;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Get the chunk field without transferring ownership
+
+zchunk_t *
+zpipes_msg_chunk (zpipes_msg_t *self)
+{
+    assert (self);
+    return self->chunk;
+}
+
+//  Get the chunk field and transfer ownership to caller
+
+zchunk_t *
+zpipes_msg_get_chunk (zpipes_msg_t *self)
+{
+    zchunk_t *chunk = self->chunk;
+    self->chunk = NULL;
+    return chunk;
+}
+
+//  Set the chunk field, transferring ownership from caller
+
+void
+zpipes_msg_set_chunk (zpipes_msg_t *self, zchunk_t **chunk_p)
+{
+    assert (self);
+    assert (chunk_p);
+    zchunk_destroy (&self->chunk);
+    self->chunk = *chunk_p;
+    *chunk_p = NULL;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Selftest
+
+int
+zpipes_msg_test (bool verbose)
+{
+    printf (" * zpipes_msg: ");
+
+    //  @selftest
+    //  Simple create/destroy test
+    zpipes_msg_t *self = zpipes_msg_new (0);
+    assert (self);
+    zpipes_msg_destroy (&self);
+
+    //  Encode/decode and verify each message type
+    zpipes_msg_t *copy;
+    self = zpipes_msg_new (ZPIPES_MSG_INPUT);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_pipename (self, "Life is short but Now lasts for ever");
+
+    assert (streq (zpipes_msg_pipename (self), "Life is short but Now lasts for ever"));
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_INPUT_OK);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_INPUT_FAILED);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_reason (self, "Life is short but Now lasts for ever");
+
+    assert (streq (zpipes_msg_reason (self), "Life is short but Now lasts for ever"));
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_OUTPUT);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_pipename (self, "Life is short but Now lasts for ever");
+
+    assert (streq (zpipes_msg_pipename (self), "Life is short but Now lasts for ever"));
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_OUTPUT_OK);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_OUTPUT_FAILED);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_reason (self, "Life is short but Now lasts for ever");
+
+    assert (streq (zpipes_msg_reason (self), "Life is short but Now lasts for ever"));
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_READ);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_size (self, 123);
+    zpipes_msg_set_timeout (self, 123);
+
+    assert (zpipes_msg_size (self) == 123);
+    assert (zpipes_msg_timeout (self) == 123);
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_READ_OK);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zchunk_t *read_ok_chunk = zchunk_new ("Captcha Diem", 12);
+    zpipes_msg_set_chunk (self, &read_ok_chunk);
+
+    assert (memcmp (zchunk_data (zpipes_msg_chunk (self)), "Captcha Diem", 12) == 0);
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_READ_END);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_READ_TIMEOUT);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_READ_FAILED);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_reason (self, "Life is short but Now lasts for ever");
+
+    assert (streq (zpipes_msg_reason (self), "Life is short but Now lasts for ever"));
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_WRITE);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zchunk_t *write_chunk = zchunk_new ("Captcha Diem", 12);
+    zpipes_msg_set_chunk (self, &write_chunk);
+    zpipes_msg_set_timeout (self, 123);
+
+    assert (memcmp (zchunk_data (zpipes_msg_chunk (self)), "Captcha Diem", 12) == 0);
+    assert (zpipes_msg_timeout (self) == 123);
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_WRITE_OK);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_WRITE_TIMEOUT);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_WRITE_FAILED);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_reason (self, "Life is short but Now lasts for ever");
+
+    assert (streq (zpipes_msg_reason (self), "Life is short but Now lasts for ever"));
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_CLOSE);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_CLOSE_OK);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_CLOSE_FAILED);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+    zpipes_msg_set_reason (self, "Life is short but Now lasts for ever");
+
+    assert (streq (zpipes_msg_reason (self), "Life is short but Now lasts for ever"));
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_PING);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_PING_OK);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    self = zpipes_msg_new (ZPIPES_MSG_INVALID);
+    
+    //  Check that _dup works on empty message
+    copy = zpipes_msg_dup (self);
+    assert (copy);
+    zpipes_msg_destroy (&copy);
+
+
+    zpipes_msg_destroy (&self);
+    //  @end
+
+    printf ("OK\n");
+    return 0;
+}

--- a/clients/zpipes_msg.h
+++ b/clients/zpipes_msg.h
@@ -1,0 +1,299 @@
+/*  =========================================================================
+    zpipes_msg - ZPIPES protocol
+    
+    Codec header for zpipes_msg.
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+    * The XML model used for this code generation: zpipes_msg.xml
+    * The code generation script that built this file: codec_libzmtp
+    ************************************************************************
+    Copyright (c) the Contributors as noted in the AUTHORS file.       
+    This file is part of zbroker, the ZeroMQ broker project.           
+                                                                       
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.           
+    =========================================================================
+*/
+
+#ifndef __ZPIPES_MSG_H_INCLUDED__
+#define __ZPIPES_MSG_H_INCLUDED__
+
+/*  These are the zpipes_msg messages:
+
+    INPUT - Create a new pipe for reading
+        pipename            string      Name of pipe
+
+    INPUT_OK - Input request was successful
+
+    INPUT_FAILED - Input request failed
+        reason              string      Reason for failure
+
+    OUTPUT - Create a new pipe for writing
+        pipename            string      Name of pipe
+
+    OUTPUT_OK - Output request was successful
+
+    OUTPUT_FAILED - Output request failed
+        reason              string      Reason for failure
+
+    READ - Read a chunk of data from pipe
+        size                number 4    Number of bytes to read
+        timeout             number 4    Timeout, msecs, or zero
+
+    READ_OK - Read was successful
+        chunk               chunk       Chunk of data
+
+    READ_END - Pipe is closed, no more data
+
+    READ_TIMEOUT - Read ended with timeout
+
+    READ_FAILED - Read failed due to error
+        reason              string      Reason for failure
+
+    WRITE - Write chunk of data to pipe
+        chunk               chunk       Chunk of data
+        timeout             number 4    Timeout, msecs, or zero
+
+    WRITE_OK - Write was successful
+
+    WRITE_TIMEOUT - Write ended with timeout
+
+    WRITE_FAILED - Read failed due to error
+        reason              string      Reason for failure
+
+    CLOSE - Close pipe
+
+    CLOSE_OK - Close was successful
+
+    CLOSE_FAILED - Close failed due to error
+        reason              string      Reason for failure
+
+    PING - Signal liveness
+
+    PING_OK - Respond to ping
+
+    INVALID - Command was invalid at this time
+*/
+
+
+#define ZPIPES_MSG_INPUT                    1
+#define ZPIPES_MSG_INPUT_OK                 2
+#define ZPIPES_MSG_INPUT_FAILED             3
+#define ZPIPES_MSG_OUTPUT                   4
+#define ZPIPES_MSG_OUTPUT_OK                5
+#define ZPIPES_MSG_OUTPUT_FAILED            6
+#define ZPIPES_MSG_READ                     7
+#define ZPIPES_MSG_READ_OK                  8
+#define ZPIPES_MSG_READ_END                 9
+#define ZPIPES_MSG_READ_TIMEOUT             10
+#define ZPIPES_MSG_READ_FAILED              11
+#define ZPIPES_MSG_WRITE                    12
+#define ZPIPES_MSG_WRITE_OK                 13
+#define ZPIPES_MSG_WRITE_TIMEOUT            14
+#define ZPIPES_MSG_WRITE_FAILED             15
+#define ZPIPES_MSG_CLOSE                    16
+#define ZPIPES_MSG_CLOSE_OK                 17
+#define ZPIPES_MSG_CLOSE_FAILED             18
+#define ZPIPES_MSG_PING                     19
+#define ZPIPES_MSG_PING_OK                  20
+#define ZPIPES_MSG_INVALID                  21
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  Opaque class structure
+typedef struct _zpipes_msg_t zpipes_msg_t;
+
+//  @interface
+//  Create a new zpipes_msg
+zpipes_msg_t *
+    zpipes_msg_new (int id);
+
+//  Destroy the zpipes_msg
+void
+    zpipes_msg_destroy (zpipes_msg_t **self_p);
+
+//  Parse a zpipes_msg from zmtp_msg_t. Returns a new object, or NULL 
+//  if the message could not be parsed, or was NULL. Nullifies the msg
+//  reference.
+zpipes_msg_t *
+    zpipes_msg_decode (zmtp_msg_t **msg_p);
+
+//  Encode zpipes_msg into a message. Returns a newly created object
+//  or NULL if error. Use when not in control of sending the message.
+//  Destroys the zpipes_msg_t instance.
+zmtp_msg_t *
+    zpipes_msg_encode (zpipes_msg_t **self_p);
+
+//  Receive and parse a zpipes_msg from the socket. Returns new object,
+//  or NULL if error. Will block if there's no message waiting.
+CZMQ_EXPORT zpipes_msg_t *
+    zpipes_msg_recv (zmtp_dealer_t *input);
+
+//  Send the zpipes_msg to the output, and destroy it
+CZMQ_EXPORT int
+    zpipes_msg_send (zpipes_msg_t **self_p, zmtp_dealer_t *output);
+
+//  Send the INPUT to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_input (zmtp_dealer_t *output,
+        const char *pipename);
+
+//  Send the INPUT_OK to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_input_ok (zmtp_dealer_t *output);
+
+//  Send the INPUT_FAILED to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_input_failed (zmtp_dealer_t *output,
+        const char *reason);
+
+//  Send the OUTPUT to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_output (zmtp_dealer_t *output,
+        const char *pipename);
+
+//  Send the OUTPUT_OK to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_output_ok (zmtp_dealer_t *output);
+
+//  Send the OUTPUT_FAILED to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_output_failed (zmtp_dealer_t *output,
+        const char *reason);
+
+//  Send the READ to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_read (zmtp_dealer_t *output,
+        uint32_t size,
+        uint32_t timeout);
+
+//  Send the READ_OK to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_read_ok (zmtp_dealer_t *output,
+        zchunk_t *chunk);
+
+//  Send the READ_END to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_read_end (zmtp_dealer_t *output);
+
+//  Send the READ_TIMEOUT to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_read_timeout (zmtp_dealer_t *output);
+
+//  Send the READ_FAILED to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_read_failed (zmtp_dealer_t *output,
+        const char *reason);
+
+//  Send the WRITE to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_write (zmtp_dealer_t *output,
+        zchunk_t *chunk,
+        uint32_t timeout);
+
+//  Send the WRITE_OK to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_write_ok (zmtp_dealer_t *output);
+
+//  Send the WRITE_TIMEOUT to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_write_timeout (zmtp_dealer_t *output);
+
+//  Send the WRITE_FAILED to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_write_failed (zmtp_dealer_t *output,
+        const char *reason);
+
+//  Send the CLOSE to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_close (zmtp_dealer_t *output);
+
+//  Send the CLOSE_OK to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_close_ok (zmtp_dealer_t *output);
+
+//  Send the CLOSE_FAILED to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_close_failed (zmtp_dealer_t *output,
+        const char *reason);
+
+//  Send the PING to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_ping (zmtp_dealer_t *output);
+
+//  Send the PING_OK to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_ping_ok (zmtp_dealer_t *output);
+
+//  Send the INVALID to the output in one step
+CZMQ_EXPORT int
+    zpipes_msg_send_invalid (zmtp_dealer_t *output);
+
+//  Duplicate the zpipes_msg message
+zpipes_msg_t *
+    zpipes_msg_dup (zpipes_msg_t *self);
+
+//  Print contents of message to stdout
+void
+    zpipes_msg_dump (zpipes_msg_t *self);
+
+//  Get the zpipes_msg id and printable command
+int
+    zpipes_msg_id (zpipes_msg_t *self);
+void
+    zpipes_msg_set_id (zpipes_msg_t *self, int id);
+const char *
+    zpipes_msg_command (zpipes_msg_t *self);
+
+//  Get/set the pipename field
+const char *
+    zpipes_msg_pipename (zpipes_msg_t *self);
+void
+    zpipes_msg_set_pipename (zpipes_msg_t *self, const char *format, ...);
+
+//  Get/set the reason field
+const char *
+    zpipes_msg_reason (zpipes_msg_t *self);
+void
+    zpipes_msg_set_reason (zpipes_msg_t *self, const char *format, ...);
+
+//  Get/set the size field
+uint32_t
+    zpipes_msg_size (zpipes_msg_t *self);
+void
+    zpipes_msg_set_size (zpipes_msg_t *self, uint32_t size);
+
+//  Get/set the timeout field
+uint32_t
+    zpipes_msg_timeout (zpipes_msg_t *self);
+void
+    zpipes_msg_set_timeout (zpipes_msg_t *self, uint32_t timeout);
+
+//  Get a copy of the chunk field
+zchunk_t *
+    zpipes_msg_chunk (zpipes_msg_t *self);
+//  Get the chunk field and transfer ownership to caller
+zchunk_t *
+    zpipes_msg_get_chunk (zpipes_msg_t *self);
+//  Set the chunk field, transferring ownership from caller
+void
+    zpipes_msg_set_chunk (zpipes_msg_t *self, zchunk_t **chunk_p);
+
+//  Self test of this class
+int
+    zpipes_msg_test (bool verbose);
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/clients/zpipes_msg.xml
+++ b/clients/zpipes_msg.xml
@@ -1,0 +1,121 @@
+<class
+    name = "zpipes_msg"
+    title = "ZPIPES protocol"
+    script = "codec_libzmtp"
+    >
+    This is a codec for the ZPIPES protocol (RFC tbd)
+    <include filename = "license.xml" />
+
+    <grammar>
+    ZPIPES = reader | writer
+
+    reader = input-command *( read-command | ping-command )
+             close-command
+    input-command = c:input ( s:input-ok | s:input-failed )
+    read-command = c:read ( s:read-ok | s:read-end
+                          | s:read-timeout | s:read-failed )
+    close-command = c:close ( s:close-ok | s:close-failed )
+
+    writer = output-command *write-command close-command
+    output-command = c:output ( s:output-ok | s:output-failed )
+    write-command = c:write ( s:write-ok
+                            | s:write-timeout | s:write-failed )
+    ping-command = c:ping s:ping-ok
+    </grammar>
+
+    <message name = "input">
+        Create a new pipe for reading
+        <field name = "pipename" type = "string">Name of pipe</field>
+    </message>
+
+    <message name = "input ok">
+        Input request was successful
+    </message>
+
+    <message name = "input failed">
+        Input request failed
+        <field name = "reason" type = "string">Reason for failure</field>
+    </message>
+
+    <message name = "output">
+        Create a new pipe for writing
+        <field name = "pipename" type = "string">Name of pipe</field>
+    </message>
+
+    <message name = "output ok">
+        Output request was successful
+    </message>
+
+    <message name = "output failed">
+        Output request failed
+        <field name = "reason" type = "string">Reason for failure</field>
+    </message>
+    
+    <message name = "read">
+        Read a chunk of data from pipe
+        <field name = "size" type = "number" size = "4">Number of bytes to read</field>
+        <field name = "timeout" type = "number" size = "4">Timeout, msecs, or zero</field>
+    </message>
+
+    <message name = "read ok">
+        Read was successful
+        <field name = "chunk" type = "chunk">Chunk of data</field>
+    </message>
+
+    <message name = "read end">
+        Pipe is closed, no more data
+    </message>
+
+    <message name = "read timeout">
+        Read ended with timeout
+    </message>
+
+    <message name = "read failed">
+        Read failed due to error
+        <field name = "reason" type = "string">Reason for failure</field>
+    </message>
+
+    <message name = "write">
+        Write chunk of data to pipe
+        <field name = "chunk" type = "chunk">Chunk of data</field>
+        <field name = "timeout" type = "number" size = "4">Timeout, msecs, or zero</field>
+    </message>
+
+    <message name = "write ok">
+        Write was successful
+    </message>
+
+    <message name = "write timeout">
+        Write ended with timeout
+    </message>
+
+    <message name = "write failed">
+        Read failed due to error
+        <field name = "reason" type = "string">Reason for failure</field>
+    </message>
+
+    <message name = "close">
+        Close pipe
+    </message>
+
+    <message name = "close ok">
+        Close was successful
+    </message>
+    
+    <message name = "close failed">
+        Close failed due to error
+        <field name = "reason" type = "string">Reason for failure</field>
+    </message>
+    
+    <message name = "ping">
+        Signal liveness
+    </message>
+
+    <message name = "ping ok">
+        Respond to ping
+    </message>
+    
+    <message name = "invalid">
+        Command was invalid at this time
+    </message>
+</class>

--- a/configure.ac
+++ b/configure.ac
@@ -275,5 +275,11 @@ AC_TYPE_SIGNAL
 AC_CHECK_FUNCS(perror gettimeofday memset getifaddrs freeifaddrs)
 
 # Specify output files
-AC_CONFIG_FILES([Makefile src/Makefile doc/Makefile src/libzbroker.pc src/libzpipesclient.pc])
+AC_CONFIG_FILES([
+    Makefile
+    src/Makefile
+    src/libzbroker.pc
+    clients/Makefile
+    clients/libzbroker_cli.pc
+    doc/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
-lib_LTLIBRARIES = libzbroker.la libzpipesclient.la
+lib_LTLIBRARIES = libzbroker.la
 
 pkgconfigdir = $(libdir)/pkgconfig
-pkgconfig_DATA = libzbroker.pc libzpipesclient.pc
+pkgconfig_DATA = libzbroker.pc
 
 include_HEADERS = \
 	../include/zbroker.h \
@@ -11,23 +11,19 @@ include_HEADERS = \
 
 libzbroker_la_SOURCES = \
 	zpipes_msg.c \
+	zpipes_client.c \
 	zpipes_server.c \
 	zpipes_server_engine.h
-	
-libzpipesclient_la_SOURCES = \
-	zpipes_client.c
 
 AM_CFLAGS = -g
 AM_CPPFLAGS = -I$(top_srcdir)/include
 bin_PROGRAMS = zbroker zbroker_selftest zpipes_test_cluster
 
-zbroker_selftest_LDADD = libzbroker.la libzpipesclient.la
-zpipes_test_cluster_LDADD = libzbroker.la libzpipesclient.la
-
 zbroker_LDADD = libzbroker.la
+zbroker_selftest_LDADD = libzbroker.la
+zpipes_test_cluster_LDADD = libzbroker.la
 
 libzbroker_la_LDFLAGS = -version-info @LTVER@
-libzpipesclient_la_LDFLAGS = -version-info @CLIENT_LTVER@
 
 TESTS = zbroker_selftest zpipes_test_cluster
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,7 +17,8 @@ libzbroker_la_SOURCES = \
 
 AM_CFLAGS = -g
 AM_CPPFLAGS = -I$(top_srcdir)/include
-bin_PROGRAMS = zbroker zbroker_selftest zpipes_test_cluster
+bin_PROGRAMS = zbroker
+noinst_PROGRAMS = zbroker_selftest zpipes_test_cluster
 
 zbroker_LDADD = libzbroker.la
 zbroker_selftest_LDADD = libzbroker.la

--- a/src/zbroker.c
+++ b/src/zbroker.c
@@ -10,7 +10,6 @@
     =========================================================================
 */
 
-
 #include "zbroker_classes.h"
 
 #define PRODUCT         "zbroker service/0.0.1"

--- a/src/zbroker.c
+++ b/src/zbroker.c
@@ -19,6 +19,10 @@
 "This Software is provided under the MPLv2 License on an \"as is\" basis,\n" \
 "without warranty of any kind, either expressed, implied, or statutory.\n"
 
+//  Helpers that should move into CZMQ/zsys
+static int
+s_zsys_run_as (const char *lockfile, const char *group, const char *user);
+
 int main (int argc, char *argv [])
 {
     puts (PRODUCT);
@@ -36,31 +40,122 @@ int main (int argc, char *argv [])
         config_file = argv [1];
     
     //  Load config file for our own use here
-    zclock_log ("I: starting zpipes server using config in '%s'", config_file);
+    zclock_log ("I: starting zpipes broker using config in '%s'", config_file);
     zconfig_t *config = zconfig_load (config_file);
     if (config) {
-        //  Do we want to run server in the background?
+        //  Switch to user/group to run process under, if any
+        if (s_zsys_run_as (
+            zconfig_resolve (config, "server/lockfile", NULL),
+            zconfig_resolve (config, "server/group", NULL),
+            zconfig_resolve (config, "server/user", NULL)))
+            return -1;
+
+        //  Do we want to run broker in the background?
         int as_daemon = atoi (zconfig_resolve (config, "server/background", "0"));
         const char *workdir = zconfig_resolve (config, "server/workdir", ".");
         if (as_daemon) {
             zclock_log ("I: broker switching to background process...");
-            zsys_daemonize (workdir);
+            if (zsys_daemonize (workdir))
+                return -1;
         }
         zconfig_destroy (&config);
     }
     else {
-        zclock_log ("E: cannot load config file '%s'\\n", config_file);
+        zclock_log ("E: cannot load config file '%s'\n", config_file);
         return 1;
     }
     zpipes_server_t *zpipes_server = zpipes_server_new ();
     zpipes_server_configure (zpipes_server, config_file);
-    
+
     //  Wait until process is interrupted
     while (!zctx_interrupted)
         zclock_sleep (1000);
+
     puts ("interrupted");
 
     //  Shutdown all services
     zpipes_server_destroy (&zpipes_server);
+    return 0;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Set-up the process to run as a specified group and user.
+//  First, if lockfile is specified, tries to grab a write lock on that
+//  file, and if successful, dumps the process ID into the file. This
+//  prevents two instances of the process from starting up by accident.
+//  Second, if group is specified, switches to using that group. Third,
+//  if user is specified, switches to using that group. If user is null,
+//  switches to the real user ID after dropping the PID into the lockfile.
+//  Returns 0 on success, -1 on any error.
+
+static int
+s_zsys_run_as (const char *lockfile, const char *group, const char *user)
+{
+    //  Switch to effective user ID (who owns executable); for
+    //  system services this should be root, so that we can write
+    //  the PID file into e.g. /var/run/
+    if (seteuid (geteuid ())) {
+        zclock_log ("E: cannot set effective user id: %s\n",
+                    strerror (errno));
+        return -1;
+    }
+    if (lockfile) {
+        //  We enforce a lock on the lockfile, if specified, so that
+        //  only one copy of the process can run at once.
+        int handle = open (lockfile, O_RDWR | O_CREAT, 0640);
+        if (handle < 0) {
+            zclock_log ("E: cannot open lockfile '%s': %s\n",
+                        lockfile, strerror (errno));
+            return -1;          
+        }
+        else {
+            struct flock filelock;
+            filelock.l_type   = F_WRLCK;    //  F_RDLCK, F_WRLCK, F_UNLCK
+            filelock.l_whence = SEEK_SET;   //  SEEK_SET, SEEK_CUR, SEEK_END
+            filelock.l_start  = 0;          //  Offset from l_whence
+            filelock.l_len    = 0;          //  length, 0 = to EOF
+            filelock.l_pid    = getpid ();
+            if (fcntl (handle, F_SETLK, &filelock)) {
+                zclock_log ("E: cannot get lock: %s\n", strerror (errno));
+                return -1;              
+            }
+        }
+        //   We record the broker's process id in the lock file
+        char pid_buffer [10];
+        snprintf (pid_buffer, sizeof (pid_buffer), "%6d\n", getpid ());
+        if (write (handle, pid_buffer, strlen (pid_buffer)) != strlen (pid_buffer)) {
+            zclock_log ("E: cannot write to lockfile: %s\n",
+                        strerror (errno));
+            return -1;
+        }
+        close (handle);
+    }
+    if (group) {
+        zclock_log ("I: broker running under group '%s'", group);
+        struct group *grpbuf = NULL;
+        grpbuf = getgrnam (group);
+        if (grpbuf == NULL || setgid (grpbuf->gr_gid)) {
+            zclock_log ("E: could not switch group: %s", strerror (errno));
+            return -1;
+        }
+    }
+    if (user) {
+        zclock_log ("I: broker running under user '%s'", user);
+        struct passwd *pwdbuf = NULL;
+        pwdbuf = getpwnam (user);
+        if (pwdbuf == NULL || setuid (pwdbuf->pw_uid)) {
+            zclock_log ("E: could not switch user: %s", strerror (errno));
+            return -1;
+        }
+    }
+    else {
+        //  Switch back to real user ID (who started process)
+        if (setuid (getuid ())) {
+            zclock_log ("E: cannot set real user id: %s\n",
+                        strerror (errno));
+            return -1;
+        }
+    }
     return 0;
 }

--- a/src/zbroker.cfg
+++ b/src/zbroker.cfg
@@ -6,9 +6,9 @@ server
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
     animate = 1         #   Do we animate or not?
-    user = ph           #   Run as this user
-    group = ph          #   Run as this group
-    lockfile = /var/run/zbroker.pid
+    # user = ph           #   Run as this user
+    # group = ph          #   Run as this group
+    # lockfile = /var/run/zbroker.pid
 
 #   Apply to the zpipes server only
 zpipes_server

--- a/src/zbroker.cfg
+++ b/src/zbroker.cfg
@@ -5,7 +5,10 @@ server
     timeout = 10        #   Client connection timeout
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
-    animate = 1
+    animate = 1         #   Do we animate or not?
+    user = ph           #   Run as this user
+    group = ph          #   Run as this group
+    lockfile = /var/run/zbroker.pid
 
 #   Apply to the zpipes server only
 zpipes_server

--- a/src/zbroker_classes.h
+++ b/src/zbroker_classes.h
@@ -16,8 +16,7 @@
 
 //  External API
 #include "../include/zbroker.h"
-#include "../include/zpipes_msg.h"
-#include "../include/zpipes_server.h"
-#include "../include/zpipes_client.h"
+
+//  Internal API
 
 #endif

--- a/src/zpipes_msg.c
+++ b/src/zpipes_msg.c
@@ -358,55 +358,6 @@ zpipes_msg_decode (zmsg_t **msg_p)
 
 
 //  --------------------------------------------------------------------------
-//  Receive and parse a zpipes_msg from the socket. Returns new object or
-//  NULL if error. Will block if there's no message waiting.
-
-zpipes_msg_t *
-zpipes_msg_recv (void *input)
-{
-    assert (input);
-    zmsg_t *msg = zmsg_recv (input);
-    //  If message came from a router socket, first frame is routing_id
-    zframe_t *routing_id = NULL;
-    if (zsocket_type (input) == ZMQ_ROUTER) {
-        routing_id = zmsg_pop (msg);
-        //  If message was not valid, forget about it
-        if (!routing_id || !zmsg_next (msg))
-            return NULL;        //  Malformed or empty
-    }
-    zpipes_msg_t * zpipes_msg = zpipes_msg_decode (&msg);
-    if (zsocket_type (input) == ZMQ_ROUTER)
-        zpipes_msg->routing_id = routing_id;
-        
-    return zpipes_msg;
-}
-
-
-//  --------------------------------------------------------------------------
-//  Receive and parse a zpipes_msg from the socket. Returns new object, 
-//  or NULL either if there was no input waiting, or the recv was interrupted.
-
-zpipes_msg_t *
-zpipes_msg_recv_nowait (void *input)
-{
-    assert (input);
-    zmsg_t *msg = zmsg_recv_nowait (input);
-    //  If message came from a router socket, first frame is routing_id
-    zframe_t *routing_id = NULL;
-    if (zsocket_type (input) == ZMQ_ROUTER) {
-        routing_id = zmsg_pop (msg);
-        //  If message was not valid, forget about it
-        if (!routing_id || !zmsg_next (msg))
-            return NULL;        //  Malformed or empty
-    }
-    zpipes_msg_t * zpipes_msg = zpipes_msg_decode (&msg);
-    if (zsocket_type (input) == ZMQ_ROUTER)
-        zpipes_msg->routing_id = routing_id;
-        
-    return zpipes_msg;
-}
-
-
 //  Encode zpipes_msg into zmsg and destroy it. Returns a newly created
 //  object or NULL if error. Use when not in control of sending the message.
 //  If the socket_type is ZMQ_ROUTER, then stores the routing_id as the
@@ -669,6 +620,56 @@ zpipes_msg_encode (zpipes_msg_t **self_p)
     //  Destroy zpipes_msg object
     zpipes_msg_destroy (self_p);
     return msg;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Receive and parse a zpipes_msg from the socket. Returns new object or
+//  NULL if error. Will block if there's no message waiting.
+
+zpipes_msg_t *
+zpipes_msg_recv (void *input)
+{
+    assert (input);
+    zmsg_t *msg = zmsg_recv (input);
+    //  If message came from a router socket, first frame is routing_id
+    zframe_t *routing_id = NULL;
+    if (zsocket_type (input) == ZMQ_ROUTER) {
+        routing_id = zmsg_pop (msg);
+        //  If message was not valid, forget about it
+        if (!routing_id || !zmsg_next (msg))
+            return NULL;        //  Malformed or empty
+    }
+    zpipes_msg_t * zpipes_msg = zpipes_msg_decode (&msg);
+    if (zsocket_type (input) == ZMQ_ROUTER)
+        zpipes_msg->routing_id = routing_id;
+
+    return zpipes_msg;
+}
+
+
+//  --------------------------------------------------------------------------
+//  Receive and parse a zpipes_msg from the socket. Returns new object,
+//  or NULL either if there was no input waiting, or the recv was interrupted.
+
+zpipes_msg_t *
+zpipes_msg_recv_nowait (void *input)
+{
+    assert (input);
+    zmsg_t *msg = zmsg_recv_nowait (input);
+    //  If message came from a router socket, first frame is routing_id
+    zframe_t *routing_id = NULL;
+    if (zsocket_type (input) == ZMQ_ROUTER) {
+        routing_id = zmsg_pop (msg);
+        //  If message was not valid, forget about it
+        if (!routing_id || !zmsg_next (msg))
+            return NULL;        //  Malformed or empty
+    }
+    zpipes_msg_t * zpipes_msg = zpipes_msg_decode (&msg);
+    if (zsocket_type (input) == ZMQ_ROUTER)
+        zpipes_msg->routing_id = routing_id;
+
+    return zpipes_msg;
 }
 
 

--- a/src/zpipes_server.c
+++ b/src/zpipes_server.c
@@ -260,6 +260,10 @@ pipe_attach_remote_reader (pipe_t *self, const char *remote, bool unicast)
             zyre_whisper (self->server->zyre, self->remote, &msg);
             zclock_log ("%s: tell peer we are now writer", self->name);
         }
+        //  Writer must be local at this stage; wake it up so it can
+        //  ship off its waiting data
+        assert (self->writer != REMOTE_NODE);
+        engine_send_event (self->writer, have_reader_event);
         return 0;
     }
     zclock_log ("%s: pipe already has reader: ignored", self->name);

--- a/src/zpipes_server.c
+++ b/src/zpipes_server.c
@@ -18,10 +18,7 @@
 @end
 */
 
-#include <czmq.h>
-#include <zyre.h>
-#include "../include/zpipes_msg.h"
-#include "../include/zpipes_server.h"
+#include "zbroker_classes.h"
 
 //  This method handles all traffic from other server nodes
 

--- a/src/zpipes_test_cluster.c
+++ b/src/zpipes_test_cluster.c
@@ -1,4 +1,14 @@
-//  Test zpipes over a cluster
+/*  =========================================================================
+    zpipes_test_cluster - test zpipes over a cluster
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of zbroker, the ZeroMQ broker project.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
 
 #include "zbroker.h"
 

--- a/src/zpipes_test_cluster.c
+++ b/src/zpipes_test_cluster.c
@@ -10,7 +10,7 @@
     =========================================================================
 */
 
-#include "zbroker.h"
+#include "zbroker_classes.h"
 
 static void
 s_wait (char *message)

--- a/src/zpipes_test_cluster.c
+++ b/src/zpipes_test_cluster.c
@@ -105,8 +105,10 @@ int main (void)
 
     s_wait ("Open reader reusing pipe name");
     reader = zpipes_client_new ("hosta", "test pipe 2");
+    zpipes_client_destroy (&reader);
 
     zpipes_server_destroy (&hosta);
     zpipes_server_destroy (&hostb);
+    zclock_sleep (100);
     return 0;
 }


### PR DESCRIPTION
- sets effective UID, typically root
- grabs write lock on server/lockfile (e.g. /var/run/zbroker.pid)
- dumps PID into lockfile
- sets group and/or user from server/group, server/user
- else sets back to real UID

Note, does not work using normal 'make' as zbroker isn't the real binary.
Here is how I build/test:

```
MAIN=zbroker
sudo rm $MAIN
gcc -g -o $MAIN \
    $MAIN.c \
    zpipes_msg.c zpipes_client.c zpipes_server.c \
    -lczmq -lzmq -lzyre -luuid -lsodium
test $? -ne 0 && exit

sudo chown root $MAIN
sudo chgrp root $MAIN
sudo chmod +s $MAIN
./$MAIN
```

Note example of zbroker.cfg:

```
server
    timeout = 10        #   Client connection timeout
    background = 0      #   Run as background process
    workdir = .         #   Working directory for daemon
    animate = 1         #   Do we animate or not?
    user = ph           #   Run as this user
    group = ph          #   Run as this group
    lockfile = /var/run/zbroker.pid
```

Fixes #52
Fixes #53
