### PR TITLE
Unpin czmq from 2.2.0 on travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_script:
 - git clone git://github.com/jedisct1/libsodium.git
 - git clone git://github.com/zeromq/zeromq4-x.git
 - git clone git://github.com/zeromq/czmq.git
-- cd czmq && git checkout v2.2.0 && cd ..
 - git clone git://github.com/zeromq/zyre.git
 - cd zyre && git checkout v1.0.0 && cd ..
 - git clone git://github.com/zeromq/libzmtp.git


### PR DESCRIPTION
the zsock stuff just landed in czmq trunk, and we'll track trunk
until a new stable on czmq.
