### PR TITLE
Pull values from config file before starting Zyre

### DIFF
--- a/src/zbroker-daemon.cfg
+++ b/src/zbroker-daemon.cfg
@@ -15,3 +15,10 @@ zpipes_server
     echo = binding zpipes service to 'ipc://@/zpipes/local'
     bind
         endpoint = ipc://@/zpipes/local
+
+#   Zyre cluster configuration
+zyre
+    port = 5670         #   Default = 5670
+    interval = 250      #   Default = 1000 msec
+#    name = somenode     #   Override generated node name
+#    interface = eth0    #   Use this network interface

--- a/src/zbroker.c
+++ b/src/zbroker.c
@@ -61,7 +61,12 @@ int main (int argc, char *argv [])
     }
     zactor_t *server = zactor_new (zpipes_server, NULL);
     zstr_sendx (server, "CONFIGURE", config_file, NULL);
-    zstr_sendx (server, "JOIN CLUSTER", "hosta", NULL);
+    zstr_sendx (server, "JOIN CLUSTER", NULL);
+    
+    char *reply = zstr_recv (server);
+    if (strneq (reply, "OK"))
+        zclock_log ("W: no UDP discovery, cannot join cluster");
+    free (reply);
     
     //  Accept and print any message back from server
     while (true) {

--- a/src/zbroker.cfg
+++ b/src/zbroker.cfg
@@ -17,6 +17,6 @@ zpipes_server
 zyre
     port = 5670         #   Default = 5670
     interval = 250      #   Default = 1000 msec
-    nodeid = $auto      #   Default = automatic UUID
-    interface = $auto   #   Network interface to use
+   name = somenode     #   Override generated node name
+   interface = wlan0    #   Use this network interface
     

--- a/src/zbroker.cfg
+++ b/src/zbroker.cfg
@@ -13,3 +13,10 @@ zpipes_server
     bind
         endpoint = ipc://@/zpipes/local
 
+#   Zyre cluster configuration
+zyre
+    port = 5670         #   Default = 5670
+    interval = 250      #   Default = 1000 msec
+    nodeid = $auto      #   Default = automatic UUID
+    interface = $auto   #   Network interface to use
+    

--- a/src/zpipes_client.c
+++ b/src/zpipes_client.c
@@ -217,6 +217,9 @@ zpipes_client_test (bool verbose)
     zactor_t *server = zactor_new (zpipes_server, NULL);
     zstr_sendx (server, "SET", "server/animate", verbose? "1": "0", NULL);
     zstr_sendx (server, "BIND", "ipc://@/zpipes/local", NULL);
+    char *reply = zstr_recv (server);
+    assert (streq (reply, "0"));
+    free (reply);
     
     zpipes_client_t *reader = zpipes_client_new ("local", "test pipe");
     zpipes_client_t *writer = zpipes_client_new ("local", ">test pipe");

--- a/src/zpipes_server.c
+++ b/src/zpipes_server.c
@@ -37,7 +37,6 @@ struct _server_t {
     
     //  These properties are specific for this application
     char *name;                 //  Server public name
-    char uuid [7];              //  Truncated Zyre UUID, 6 chars
     zhash_t *pipes;             //  Collection of pipes
     zyre_t *zyre;               //  Zyre node
 };
@@ -103,6 +102,7 @@ server_initialize (server_t *self)
 static void
 server_terminate (server_t *self)
 {
+    free (self->name);
     zyre_destroy (&self->zyre);
     zhash_destroy (&self->pipes);
 }
@@ -130,27 +130,34 @@ server_method (server_t *self, const char *method, zmsg_t *msg)
 static int
 server_join_cluster (server_t *self)
 {
-    //  Get Zyre configuration properties
-    char *interval = zconfig_resolve (self->config, "zyre/interval", NULL);
-    char *port = zconfig_resolve (self->config, "zyre/port", NULL);
-    //  TODO:
-    //  - node identifier
-    //  - interface to use -> zsys_set_interface
     self->zyre = zyre_new ();
-    if (interval)
-        zyre_set_interval (self->zyre, atoi (interval));
-    if (port)
-        zyre_set_port (self->zyre, atoi (port));
+    
+    //  Get Zyre configuration properties
+    char *value = zconfig_resolve (self->config, "zyre/interval", NULL);
+    if (value)
+        zyre_set_interval (self->zyre, atoi (value));
+    
+    value = zconfig_resolve (self->config, "zyre/port", NULL);
+    if (value)
+        zyre_set_port (self->zyre, atoi (value));
+    
+    value = zconfig_resolve (self->config, "zyre/name", NULL);
+    if (value)
+        zyre_set_name (self->zyre, value);
+    
+    value = zconfig_resolve (self->config, "zyre/interface", NULL);
+    if (value)
+        zyre_set_interface (self->zyre, value);
+    
     if (zyre_start (self->zyre)) {
         zlog_warning (self->log, "clustering not working");
         return -1;              //  Can't join cluster
     }
     zyre_join (self->zyre, "ZPIPES");
 
-    //  Get 6-character Zyre UUID for logging
-    strncpy (self->uuid, zyre_uuid (self->zyre), 6);
-    self->uuid [6] = 0;
-    zlog_info (self->log, "joining cluster as %s", self->uuid);
+    //  Get Zyre public name for logging
+    self->name = strdup (zyre_name (self->zyre));
+    zlog_info (self->log, "joining cluster as %s", self->name);
 
     //  Set-up reader for Zyre events
     engine_handle_socket (self, zyre_socket (self->zyre), zyre_handler);
@@ -729,17 +736,15 @@ collect_data_to_send (client_t *self)
 static void
 server_process_cluster_command (
     server_t *self,
-    const char *remote,
+    const char *peer_id,
+    const char *peer_name,
     zmsg_t *msg,
     bool unicast)
 {
     char *request = zmsg_popstr (msg);
     char *pipename = zmsg_popstr (msg);
-    char remote_short [7];
-    strncpy (remote_short, remote, 6);
-    remote_short [6] = 0;
-    engine_server_log (self, "remote=%s command=%s pipe=%s unicast=%d",
-                       remote_short, request, pipename, unicast);
+    engine_server_log (self, "peer=%s command=%s pipe=%s unicast=%d",
+                       peer_name, request, pipename, unicast);
 
     //  Lookup or create pipe
     //  TODO: remote pipes need cleaning up with some timeout
@@ -748,10 +753,10 @@ server_process_cluster_command (
         pipe = pipe_new (self, pipename);
 
     if (streq (request, "HAVE WRITER"))
-        pipe_attach_remote_writer (pipe, remote, unicast);
+        pipe_attach_remote_writer (pipe, peer_id, unicast);
     else
     if (streq (request, "HAVE READER"))
-        pipe_attach_remote_reader (pipe, remote, unicast);
+        pipe_attach_remote_reader (pipe, peer_id, unicast);
     else
     if (streq (request, "DATA")) {
         //  TODO encode these commands as proper protocol
@@ -771,12 +776,12 @@ server_process_cluster_command (
     }
     else
     if (streq (request, "DROP READER"))
-        pipe_drop_remote_reader (&pipe, remote);
+        pipe_drop_remote_reader (&pipe, peer_id);
     else
     if (streq (request, "DROP WRITER"))
-        pipe_drop_remote_writer (&pipe, remote);
+        pipe_drop_remote_writer (&pipe, peer_id);
     else
-        zlog_warning (self->log, "bad request %s from %s", request, remote);
+        zlog_warning (self->log, "bad request %s from %s", request, peer_name);
 
     zstr_free (&pipename);
     zstr_free (&request);
@@ -792,29 +797,28 @@ zyre_handler (zloop_t *loop, zsock_t *reader, void *argument)
 
     zmsg_dump (msg);
     char *command = zmsg_popstr (msg);
-    char *remote = zmsg_popstr (msg);
-    char remote_short [7];
-    strncpy (remote_short, remote, 6);
-    remote_short [6] = 0;
+    char *peer_id = zmsg_popstr (msg);
+    char *peer_name = zmsg_popstr (msg);
 
     if (streq (command, "ENTER"))
-        zlog_info (self->log, "ZPIPES server appeared at %s", remote_short);
+        zlog_info (self->log, "ZPIPES server appeared at %s", peer_name);
     else
     if (streq (command, "EXIT"))
-        zlog_info (self->log, "ZPIPES server vanished from %s", remote_short);
+        zlog_info (self->log, "ZPIPES server vanished from %s", peer_name);
     else
     if (streq (command, "SHOUT")) {
         char *group = zmsg_popstr (msg);
         if (streq (group, "ZPIPES"))
-            server_process_cluster_command (self, remote, msg, false);
+            server_process_cluster_command (self, peer_id, peer_name, msg, false);
         zstr_free (&group);
     }
     else
     if (streq (command, "WHISPER"))
-        server_process_cluster_command (self, remote, msg, true);
+        server_process_cluster_command (self, peer_id, peer_name, msg, true);
     
     zstr_free (&command);
-    zstr_free (&remote);
+    zstr_free (&peer_id);
+    zstr_free (&peer_name);
     zmsg_destroy (&msg);
     
     return 0;
@@ -852,6 +856,9 @@ zpipes_server_test (bool verbose)
     zactor_t *server = zactor_new (zpipes_server, NULL);
     zstr_sendx (server, "SET", "server/animate", verbose? "1": "0", NULL);
     zstr_sendx (server, "BIND", "ipc://@/zpipes/local", NULL);
+    char *reply = zstr_recv (server);
+    assert (streq (reply, "0"));
+    free (reply);
 
     zsock_t *writer = zsock_new (ZMQ_DEALER);
     assert (writer);

--- a/src/zpipes_server_engine.h
+++ b/src/zpipes_server_engine.h
@@ -137,7 +137,7 @@ typedef struct {
     int expiry_timer;           //  zloop timer for client timeouts
     int wakeup_timer;           //  zloop timer for client alarms
     event_t wakeup_event;       //  Wake up with this event
-    char log_prefix [31];       //  Log prefix string
+    char log_prefix [41];       //  Log prefix string
 } s_client_t;
 
 static int
@@ -305,7 +305,7 @@ engine_set_log_prefix (client_t *client, const char *string)
     if (client) {
         s_client_t *self = (s_client_t *) client;
         snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
-            "%6d:%-20s", self->unique_id, string);
+            "%6d:%-33s", self->unique_id, string);
     }
 }
 

--- a/src/zpipes_test_cluster.c
+++ b/src/zpipes_test_cluster.c
@@ -26,12 +26,30 @@ int main (void)
     zactor_t *hosta = zactor_new (zpipes_server, NULL);
     zstr_sendx (hosta, "BIND", "ipc://@/zpipes/hosta", NULL);
     zstr_sendx (hosta, "SET", "server/animate", animate, NULL);
-    zstr_sendx (hosta, "JOIN CLUSTER", "hosta", NULL);
+    zstr_sendx (hosta, "SET", "zyre/interval", "100", NULL);
+    zstr_sendx (hosta, "SET", "zyre/nodeid", "hosta", NULL);
+    zstr_sendx (hosta, "JOIN CLUSTER", NULL);
+    char *reply = zstr_recv (hosta);
+
+    //  If the machine has no usable broadcast interface, the JOIN CLUSTER
+    //  command will fail, and then there's no point in continuing...
+    if (strneq (reply, "OK")) {
+        zclock_log ("W: skipping test, no UDP discovery");
+        free (reply);
+        zactor_destroy (&hosta);
+        return 0;
+    }
+    free (reply);
 
     zactor_t *hostb = zactor_new (zpipes_server, NULL);
     zstr_sendx (hostb, "BIND", "ipc://@/zpipes/hostb", NULL);
     zstr_sendx (hostb, "SET", "server/animate", animate, NULL);
-    zstr_sendx (hostb, "JOIN CLUSTER", "hostb", NULL);
+    zstr_sendx (hostb, "SET", "zyre/interval", "100", NULL);
+    zstr_sendx (hostb, "SET", "zyre/nodeid", "hostb", NULL);
+    zstr_sendx (hostb, "JOIN CLUSTER", NULL);
+    reply = zstr_recv (hostb);
+    assert (streq (reply, "OK"));
+    free (reply);
     
     //  Give time for cluster to interconnect
     zclock_sleep (250);

--- a/src/zpipes_test_cluster.c
+++ b/src/zpipes_test_cluster.c
@@ -22,32 +22,46 @@ s_wait (char *message)
 int main (void)
 {
     char *animate = "0";
+
+    zactor_t *green = zactor_new (zpipes_server, NULL);
+    //  BIND message always replies with port number
+    zstr_sendx (green, "BIND", "ipc://@/zpipes/green", NULL);
+    char *reply = zstr_recv (green);
+    assert (streq (reply, "0"));
+    free (reply);
     
-    zactor_t *hosta = zactor_new (zpipes_server, NULL);
-    zstr_sendx (hosta, "BIND", "ipc://@/zpipes/hosta", NULL);
-    zstr_sendx (hosta, "SET", "server/animate", animate, NULL);
-    zstr_sendx (hosta, "SET", "zyre/interval", "100", NULL);
-    zstr_sendx (hosta, "SET", "zyre/nodeid", "hosta", NULL);
-    zstr_sendx (hosta, "JOIN CLUSTER", NULL);
-    char *reply = zstr_recv (hosta);
+    zstr_sendx (green, "SET", "server/animate", animate, NULL);
+    zstr_sendx (green, "SET", "zyre/interval", "100", NULL);
+    zstr_sendx (green, "SET", "zyre/nodeid", "green", NULL);
+    
+    //  JOIN CLUSTER message always replies with OK/SNAFU
+    zstr_sendx (green, "JOIN CLUSTER", NULL);
+    reply = zstr_recv (green);
 
     //  If the machine has no usable broadcast interface, the JOIN CLUSTER
     //  command will fail, and then there's no point in continuing...
     if (strneq (reply, "OK")) {
         zclock_log ("W: skipping test, no UDP discovery");
         free (reply);
-        zactor_destroy (&hosta);
+        zactor_destroy (&green);
         return 0;
     }
     free (reply);
 
-    zactor_t *hostb = zactor_new (zpipes_server, NULL);
-    zstr_sendx (hostb, "BIND", "ipc://@/zpipes/hostb", NULL);
-    zstr_sendx (hostb, "SET", "server/animate", animate, NULL);
-    zstr_sendx (hostb, "SET", "zyre/interval", "100", NULL);
-    zstr_sendx (hostb, "SET", "zyre/nodeid", "hostb", NULL);
-    zstr_sendx (hostb, "JOIN CLUSTER", NULL);
-    reply = zstr_recv (hostb);
+    zactor_t *orange = zactor_new (zpipes_server, NULL);
+    //  BIND message always replies with port number
+    zstr_sendx (orange, "BIND", "ipc://@/zpipes/orange", NULL);
+    reply = zstr_recv (orange);
+    assert (streq (reply, "0"));
+    free (reply);
+    
+    zstr_sendx (orange, "SET", "server/animate", animate, NULL);
+    zstr_sendx (orange, "SET", "zyre/interval", "100", NULL);
+    zstr_sendx (orange, "SET", "zyre/nodeid", "orange", NULL);
+    
+    //  JOIN CLUSTER message always replies with OK/SNAFU
+    zstr_sendx (orange, "JOIN CLUSTER", NULL);
+    reply = zstr_recv (orange);
     assert (streq (reply, "OK"));
     free (reply);
     
@@ -59,10 +73,10 @@ int main (void)
 
     //  Test 1 - simple read-write
     s_wait ("Open writer");
-    zpipes_client_t *writer = zpipes_client_new ("hostb", ">test pipe");
+    zpipes_client_t *writer = zpipes_client_new ("orange", ">test pipe");
 
     s_wait ("Open reader");
-    zpipes_client_t *reader = zpipes_client_new ("hosta", "test pipe");
+    zpipes_client_t *reader = zpipes_client_new ("green", "test pipe");
 
     //  Expect timeout error, EAGAIN
     s_wait ("Read impatiently");
@@ -116,10 +130,10 @@ int main (void)
     
     //  Test 2 - pipe reuse
     s_wait ("Open reader");
-    reader = zpipes_client_new ("hosta", "test pipe 2");
+    reader = zpipes_client_new ("green", "test pipe 2");
 
     s_wait ("Open writer");
-    writer = zpipes_client_new ("hostb", ">test pipe 2");
+    writer = zpipes_client_new ("orange", ">test pipe 2");
 
     s_wait ("Close reader");
     zpipes_client_destroy (&reader);
@@ -128,10 +142,10 @@ int main (void)
     zpipes_client_destroy (&writer);
 
     s_wait ("Open reader reusing pipe name");
-    reader = zpipes_client_new ("hosta", "test pipe 2");
+    reader = zpipes_client_new ("green", "test pipe 2");
     zpipes_client_destroy (&reader);
 
-    zactor_destroy (&hosta);
-    zactor_destroy (&hostb);
+    zactor_destroy (&green);
+    zactor_destroy (&orange);
     return 0;
 }


### PR DESCRIPTION
Handles these values so far:

```
#   Zyre cluster configuration
zyre
    port = 5670         #   Default = 5670
    interval = 250      #   Default = 1000 msec
```

Also, if Zyre cannot be started, due to lack of usable network
interface, reports this and in zpipes_test_cluster, does not try
to continue tests. This tracks the latest CZMQ and Zyre masters
which provide this feedback.
